### PR TITLE
Return null for metrics without a table

### DIFF
--- a/src/main/java/com/amazon/opendistro/performanceanalyzer/metricsdb/MetricsDB.java
+++ b/src/main/java/com/amazon/opendistro/performanceanalyzer/metricsdb/MetricsDB.java
@@ -224,15 +224,32 @@ public class MetricsDB implements Removable {
         //Join all the individual metric tables to generate the final table.
         Select<Record> finalTable = null;
         for (int i = 0; i < tList.size(); i++) {
-            List<Field<?>> selectFields = DBUtils.getFieldsFromList(dimensions);
+            boolean metricTableExists = DBUtils.checkIfTableExists(create, metrics.get(i));
+            if (!metricTableExists) {
+                LOG.error(String.format("%s metric table does not exist. " +
+                        "Returning null for the metric/dimension.", metrics.get(i)));
+            }
+
+            List<Field<?>> selectFields = new ArrayList<>();
+            TableLike<Record> metricTable;
+            if (metricTableExists) {
+                selectFields = DBUtils.getFieldsFromList(dimensions);
+                metricTable = tList.get(i);
+            } else {
+                for (int j = 0; j < dimensions.size(); j ++) {
+                    selectFields.add(DSL.val(null, Double.class).as(dimensions.get(j)));
+                }
+                metricTable = create.select(selectFields).asTable();
+            }
+
             for (int j = 0; j < metrics.size(); j ++) {
-                if (i == j) {
+                if (i == j && metricTableExists) {
                     selectFields.add(DSL.field(metrics.get(i), Double.class).as(metrics.get(j)));
                 } else {
                     selectFields.add(DSL.val(null, Double.class).as(metrics.get(j)));
                 }
             }
-            Select<Record> curTable = create.select(selectFields).from(tList.get(i));
+            Select<Record> curTable = create.select(selectFields).from(metricTable);
 
             if (finalTable == null) {
                 finalTable = curTable;

--- a/src/test/java/com/amazon/opendistro/performanceanalyzer/metricsdb/MetricsDBTests.java
+++ b/src/test/java/com/amazon/opendistro/performanceanalyzer/metricsdb/MetricsDBTests.java
@@ -75,6 +75,33 @@ public class MetricsDBTests {
     }
 
     @Test
+    public void testTableNonexistent() throws Exception {
+
+        List<String> columns = Arrays.asList("shard", "index");
+        db.createMetric(Metric.cpu(10D), columns);
+
+        putCPUMetric(db, 10D, "1", "ac-test");
+        putCPUMetric(db, 4D, "1", "ac-test");
+
+        Result<Record> res = db.queryMetric(Arrays.asList("pseudocpu"),
+                Arrays.asList("sum"),
+                Arrays.asList("shard", "index"));
+        assertEquals(1, res.size());
+        assertTrue(res.get(0).get("shard") == null);
+        assertTrue(res.get(0).get("index") == null);
+
+        res = db.queryMetric(Arrays.asList("cpu", "pseudocpu"),
+                Arrays.asList("sum", "sum"),
+                Arrays.asList("shard", "index"));
+
+        assertEquals(2, res.size());
+        assertEquals(14D, Double.parseDouble(res.get(1).get("cpu").toString()), 0);
+        assertTrue(res.get(0).get("pseudocpu") == null);
+
+        db.close();
+    }
+
+    @Test
     public void testMultiMetric() throws Exception {
         List<String> columns = Arrays.asList("shard", "index");
         db.createMetric(Metric.cpu(10D), columns);


### PR DESCRIPTION
Description of changes:
- If a metric table does not exist, return "null" for its metric/dimension.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
