### PR TITLE
Changed the reader endpoint from _performanceanalyzer/metrics to _ope…

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerApp.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerApp.java
@@ -33,7 +33,7 @@ public class PerformanceAnalyzerApp {
     private static final String WEBSERVICE_PORT_CONF_NAME = "webservice-listener-port";
     //Use system default for max backlog.
     private static final int INCOMING_QUEUE_LENGTH = 1;
-    public static final String QUERY_URL = "/_performanceanalyzer/metrics";
+    public static final String QUERY_URL = "/_opendistro/_performanceanalyzer/metrics";
     private static final Logger LOG = LogManager.getLogger(PerformanceAnalyzerApp.class);
 
     public static void main(String[] args) throws Exception {


### PR DESCRIPTION

*Description of changes:*
Changed the reader endpoint from _performanceanalyzer/metrics to _opendistro/_performanceanalyzer/metrics

After the change, testing

$ curl "localhost:9600/_performanceanalyzer/metrics?metrics=Latency,CPU_Utilization&agg=avg,max&dim=ShardID&nodes=all"
<h1>404 Not Found</h1>No context found for request

$ curl "localhost:9600/_opendistro/_performanceanalyzer/metrics?metrics=Latency,CPU_Utilization&agg=avg,max&dim=ShardID&nodes=all"
{"lquiyJHUQcq-yQHaMky31w": {"timestamp": 1551376845000, "data": {"fields":[{"name":"ShardID","type":"VARCHAR"},{"name":"Latency","type":"DOUBLE"},{"name":"CPU_Utilization","type":"DOUBLE"}],"records":[[null,null,0.008]]}}}

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
