### PR TITLE
Set master event metrics sampling time to 1 second

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/MasterServiceEventMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/MasterServiceEventMetrics.java
@@ -39,7 +39,8 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.ThreadIDU
 
 @SuppressWarnings("unchecked")
 public class MasterServiceEventMetrics extends PerformanceAnalyzerMetricsCollector implements MetricsProcessor {
-    public static final int SAMPLING_TIME_INTERVAL = MetricsConfiguration.CONFIG_MAP.get(MasterServiceMetrics.class).samplingInterval;
+    public static final int SAMPLING_TIME_INTERVAL = MetricsConfiguration.CONFIG_MAP.get(
+            MasterServiceEventMetrics.class).samplingInterval;
     private static final Logger LOG = LogManager.getLogger(MasterServiceEventMetrics.class);
     private long lastTaskInsertionOrder;
     private static final int KEYS_PATH_LENGTH = 3;
@@ -127,6 +128,7 @@ public class MasterServiceEventMetrics extends PerformanceAnalyzerMetricsCollect
             } else {
                 generateFinishMetrics(startTime);
             }
+            LOG.info("Successfully collected Master Event Metrics.");
         } catch (Exception ex) {
             LOG.debug("Exception in Collecting Master Metrics: {} for startTime {}", () -> ex.toString(), () -> startTime);
         }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/MetricsConfiguration.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/MetricsConfiguration.java
@@ -21,6 +21,7 @@ import java.util.Map;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.CircuitBreakerCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.DisksCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.HeapMetricsCollector;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MasterServiceEventMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MasterServiceMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MetricsPurgeActivity;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.NetworkE2ECollector;
@@ -72,6 +73,7 @@ public class MetricsConfiguration {
         CONFIG_MAP.put(OSGlobals.class, cdefault);
         CONFIG_MAP.put(PerformanceAnalyzerMetrics.class, new MetricConfig(0, ROTATION_INTERVAL, 0));
         CONFIG_MAP.put(MetricsPurgeActivity.class, new MetricConfig(ROTATION_INTERVAL, 0, DELETION_INTERVAL));
+        CONFIG_MAP.put(MasterServiceEventMetrics.class, new MetricConfig(1000, 0, 0));
         CONFIG_MAP.put(MasterServiceMetrics.class, cdefault);
         CONFIG_MAP.put(DisksCollector.class, cdefault);
         CONFIG_MAP.put(CircuitBreakerCollector.class, cdefault);


### PR DESCRIPTION
Update the writer to sample Master Event Metrics every 1 second.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
