### PR TITLE
Bad File Descriptor error due to double VirtualMachineImpl$SocketInputStream.close

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/PerformanceAnalyzerMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/PerformanceAnalyzerMetrics.java
@@ -108,7 +108,7 @@ public class PerformanceAnalyzerMetrics {
         try {
             java.nio.file.Files.createDirectories(file.getParentFile().toPath());
         } catch (IOException ex) {
-            LOG.error(
+            LOG.debug(
                     (Supplier<?>) () -> new ParameterizedMessage(
                             "Error In Creating Directories: {} for keyPath:{}",
                             ex.toString(), keyPath),
@@ -120,7 +120,7 @@ public class PerformanceAnalyzerMetrics {
         try {
             tmpFile = writeToTmp(keyPath, value);
         } catch (Exception ex) {
-            LOG.error(
+            LOG.debug(
                     (Supplier<?>) () -> new ParameterizedMessage(
                             "Error in Writing to Tmp File: {} for keyPath:{}",
                             ex.toString(), keyPath),
@@ -131,7 +131,7 @@ public class PerformanceAnalyzerMetrics {
         try {
             tmpFile.renameTo(file);
         } catch (Exception ex) {
-            LOG.error(
+            LOG.debug(
                     (Supplier<?>) () -> new ParameterizedMessage(
                             "Error in Renaming Tmp File: {} for keyPath:{}",
                             ex.toString(), keyPath),


### PR DESCRIPTION
sun.tools.attach.VirtualMachineImpl$SocketInputStream.close not handling double close properly, which will fail in cases like try (BufferedReader br = new BufferedReader( ((HotSpotVirtualMachine) vm).remoteDataDump((Object[]) args));). Fix is: avoiding double close from client side to avoid Bad file descriptor errors

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
