### PR TITLE
Making the metricsdb files to keep around configurable.

### DIFF
--- a/pa_config/performance-analyzer.properties
+++ b/pa_config/performance-analyzer.properties
@@ -9,6 +9,13 @@ metrics-location = /dev/shm/performanceanalyzer/
 # Interval should be between 1 to 60.
 metrics-deletion-interval = 1
 
+# This decides how many, most recent metricsdb files, will be kept around.
+# Acceptable values are between -1 and 1000, not including 0. If the value
+# is set to -1, no file is ever deleted. Please don't set it to -1, unless you have
+# a way of deleting the files yourself to free up disk space. Setting it to 0 or a
+# value more than 1000 will result in error.
+max-metrics-db-files = 4
+
 # WebService exposed by App's port
 webservice-listener-port = 9600
 
@@ -30,3 +37,4 @@ plugin-stats-metadata = plugin-stats-metadata
 
 # Agent Stats Metadata file name, expected to be in the same location
 agent-stats-metadata = agent-stats-metadata
+

--- a/pa_config/performance-analyzer.properties
+++ b/pa_config/performance-analyzer.properties
@@ -9,12 +9,10 @@ metrics-location = /dev/shm/performanceanalyzer/
 # Interval should be between 1 to 60.
 metrics-deletion-interval = 1
 
-# This decides how many, most recent metricsdb files, will be kept around.
-# Acceptable values are between -1 and 1000, not including 0. If the value
-# is set to -1, no file is ever deleted. Please don't set it to -1, unless you have
-# a way of deleting the files yourself to free up disk space. Setting it to 0 or a
-# value more than 1000 will result in error.
-max-metrics-db-files = 4
+# If set to true, the system cleans up the files behind it. So at any point, we should expect only 2
+# metrics-db-file-prefix-path files. If set to false, no files are cleaned up. This can be useful, if you are archiving
+# the files and wouldn't like for them to be cleaned up.
+cleanup-metrics-db-files = true
 
 # WebService exposed by App's port
 webservice-listener-port = 9600

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metricsdb/MetricsDB.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metricsdb/MetricsDB.java
@@ -261,20 +261,18 @@ public class MetricsDB implements Removable {
         conn.commit();
     }
 
-    /**
-     * We delete the physical file on disk, only if the user has not set the DB_FILE_MAX_COUNT_CONF_NAME
-     * to -1. Otherwise we just close the connection and return.
-     **/
     @Override
     public void remove() throws Exception {
        conn.close();
-       if (PluginSettings.instance().getMaxMetricsDBFilesCount() != PluginSettings.DB_FILE_VALUE_FOR_NO_DELETION) {
-          File dbFile = new File(getDBFilePath());
-          if (!dbFile.delete()) {
-              LOG.error("Failed to delete File - {} with ExceptionCode: {}", getDBFilePath(), StatExceptionCode.OTHER.toString());
-              StatsCollector.instance().logException();
-          }
-       }
+    }
+
+    public void deleteOnDiskFile() {
+        File dbFile = new File(getDBFilePath());
+        if (!dbFile.delete()) {
+            LOG.error("Failed to delete File - {} with ExceptionCode: {}",
+                    getDBFilePath(), StatExceptionCode.OTHER.toString());
+            StatsCollector.instance().logException();
+        }
     }
 
     public Result<Record> queryMetric(String metric) {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metricsdb/MetricsDB.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metricsdb/MetricsDB.java
@@ -261,13 +261,19 @@ public class MetricsDB implements Removable {
         conn.commit();
     }
 
+    /**
+     * We delete the physical file on disk, only if the user has not set the DB_FILE_MAX_COUNT_CONF_NAME
+     * to -1. Otherwise we just close the connection and return.
+     **/
     @Override
     public void remove() throws Exception {
        conn.close();
-       File dbFile = new File(getDBFilePath());
-       if (!dbFile.delete()) {
-           LOG.error("Failed to delete File - {} with ExceptionCode: {}", getDBFilePath(), StatExceptionCode.OTHER.toString());
-           StatsCollector.instance().logException();
+       if (PluginSettings.instance().getMaxMetricsDBFilesCount() != PluginSettings.DB_FILE_VALUE_FOR_NO_DELETION) {
+          File dbFile = new File(getDBFilePath());
+          if (!dbFile.delete()) {
+              LOG.error("Failed to delete File - {} with ExceptionCode: {}", getDBFilePath(), StatExceptionCode.OTHER.toString());
+              StatsCollector.instance().logException();
+          }
        }
     }
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ReaderTrimDBTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/ReaderTrimDBTests.java
@@ -1,0 +1,157 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.reader;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metricsdb.MetricsDB;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Vector;
+import java.util.concurrent.ConcurrentSkipListMap;
+
+import static junit.framework.TestCase.assertTrue;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+
+/**
+ * Tests to make sure that the MetricsDB files are correctly deleted.
+ */
+public class ReaderTrimDBTests {
+    NavigableMap<Long, MetricsDB> metricsDBMap;
+    private Vector<String> fileNames;
+
+    @Before
+    public void setUp() {
+        metricsDBMap = new ConcurrentSkipListMap<>();
+        fileNames = new Vector<>();
+        System.setProperty("java.io.tmpdir", "/tmp");
+    }
+
+    @After
+    public void tearDown() {
+        for (String file : fileNames) {
+            File dbFile = new File(file);
+            assertEquals(true, dbFile.delete());
+        }
+    }
+
+    private void createDB(long startTime) throws Exception {
+        MetricsDB db = new MetricsDB(startTime);
+        metricsDBMap.put(startTime, new MetricsDB(startTime));
+        fileNames.add(db.getDBFilePath());
+
+    }
+
+    private void createNDBs(int start, int number) throws Exception {
+        for (long i = start; i < start + number; i++) {
+            createDB(i);
+        }
+    }
+
+    /**
+     * The trimDatabase removes all the in-memory entries from the map provided to it as an argument, leaving behind
+     * the maxFiles number of entries. This essentially tests that. Deleting the in-memory entries may or may not
+     * clean up the files from the disk. This is controlled by the the third argument. If set to false, the the files
+     * on disk are left behind. So essentially, no files will be deleted.
+     *
+     * @throws Exception if creating metricsDB file fails
+     */
+    @Test
+    public void testMetricsDBFilesNotCleaned() throws Exception {
+        int maxFiles = 2;
+        int numDBs = 10;
+
+        createNDBs(0, numDBs);
+        assertEquals(numDBs, metricsDBMap.size());
+        assertEquals(fileNames.size(), numDBs);
+
+        // Goal is to clean up the in-memory entries leaving behind the maxFiles most recent ones, but to leave the
+        // on disk files untouched.
+        ReaderMetricsProcessor.trimDatabases(metricsDBMap, maxFiles, false);
+
+        // Because deleteDBFiles is set to false, we expect no files to be deleted.
+        for (String file : fileNames) {
+            File dbFile = new File(file);
+            assertTrue(dbFile.exists());
+        }
+
+        // We check to see that only maxFiles entries are left.
+        assertEquals(metricsDBMap.size(), maxFiles);
+
+        // Add a few more files.
+        createNDBs(numDBs, numDBs);
+        assertEquals(numDBs + maxFiles, metricsDBMap.size());
+        assertEquals(numDBs * 2, fileNames.size());
+
+        // All the old and the newly created on disk files should not have been cleaned up by this call.
+        ReaderMetricsProcessor.trimDatabases(metricsDBMap, maxFiles, false);
+
+        // Because deleteDBFiles is set to false, we expect no files to be deleted.
+        for (String file : fileNames) {
+            File dbFile = new File(file);
+            assertTrue(dbFile.exists());
+        }
+
+        // We check to see that only maxFiles entries are left.
+        assertEquals(metricsDBMap.size(), maxFiles);
+    }
+
+    /**
+     * A counterpart of the testMetricsDBFilesNotCleaned test but checks that the files are cleaned up when the
+     * deleteDBFiles boolean is set to true.
+     *
+     * @throws Exception if creating metricsDB file fails
+     */
+    @Test
+    public void testMetricsDBFilesCleaned() throws Exception {
+        int maxFiles = 2;
+        int numDBs = 10;
+
+        createNDBs(0, numDBs);
+        assertEquals(metricsDBMap.size(), numDBs);
+        assertEquals(fileNames.size(), numDBs);
+
+        // The idea is to clean up the in memory entries and the on disk files leaving behind only the maxFiles
+        // number of entries.
+        ReaderMetricsProcessor.trimDatabases(metricsDBMap, maxFiles, true);
+
+        // Because deleteDBFiles is set to true, we expect only maxFiles number of files remaining.
+        int count = 0;
+        for (String file : fileNames) {
+            File dbFile = new File(file);
+            if (count < numDBs - maxFiles) {
+                assertFalse(dbFile.exists());
+            } else {
+                assertTrue(dbFile.exists());
+            }
+            count++;
+        }
+
+        assertEquals(metricsDBMap.size(), maxFiles);
+        fileNames.removeAllElements();
+
+        for (Map.Entry<Long, MetricsDB> pair : metricsDBMap.entrySet()) {
+            fileNames.add(pair.getValue().getDBFilePath());
+        }
+
+        createNDBs(numDBs, numDBs);
+        assertEquals(metricsDBMap.size(), numDBs + maxFiles);
+        assertEquals(fileNames.size(), numDBs + maxFiles);
+
+        ReaderMetricsProcessor.trimDatabases(metricsDBMap, maxFiles, true);
+
+        count = 0;
+        // Because deleteDBFiles is set to true, we expect only maxFiles number of files remaining.
+        for (String file : fileNames) {
+            File dbFile = new File(file);
+            if (count < numDBs) {
+                assertFalse("NOT expected to find file: " + file, dbFile.exists());
+            } else {
+                assertTrue("Expected to find file: " + file, dbFile.exists());
+            }
+            count++;
+        }
+    }
+}


### PR DESCRIPTION
Currently, the number of most recent metricsdb files to keep around is
determined by a code level constant. In some cases there might be a
requirement to keep more files around (or for the reader to never delete
them). This change introduces a config for that in the
performance-analyzer.properties file named 'max-metrics-db-files'.
Setting this to value -1, makes the files to never be deleted,
otherwise, the acceptable numbers are between 1 and 1000. Anything else
sets the config to default which is 4.

Github issue #47

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
