### PR TITLE
Add access logs to performance analyzer webservice

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryMetricsRequestHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryMetricsRequestHandler.java
@@ -70,6 +70,7 @@ public class QueryMetricsRequestHandler extends MetricsHandler implements HttpHa
     @Override
     public void handle(HttpExchange exchange) throws IOException {
         String requestMethod = exchange.getRequestMethod();
+        LOG.info("{} {} {}", exchange.getRequestMethod(), exchange.getRemoteAddress(), exchange.getRequestURI());
         ReaderMetricsProcessor mp = ReaderMetricsProcessor.getInstance();
         if (mp == null) {
             sendResponse(exchange,


### PR DESCRIPTION
This commit will add access logs to performance analyzer webservice. 
EG:
[2019-06-05T17:41:42,411][INFO ][c.a.o.e.p.r.QueryMetricsRequestHandler] GET /127.0.0.1:57340 /_opendistro/_performanceanalyzer/metrics?metrics=ShardBulkDocs,ShardEvents&agg=sum,sum&dim=Operation,IndexName&nodes=all
