### PR TITLE
Add elasticsearch 6.8.0 support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@
 buildscript {
 
     ext {
-        es_version = System.getProperty("es.version", "6.7.1")
+        es_version = System.getProperty("es.version", "6.8.1")
     }
     // This isn't applying from repositories.gradle so repeating it here
     repositories {
@@ -34,7 +34,7 @@ plugins {
 }
 
 ext {
-    opendistroVersion = '0.9.0'
+    opendistroVersion = '0.10.0'
     isSnapshot = "true" == System.getProperty("build.snapshot", "true")
 }
 

--- a/release-notes
+++ b/release-notes
@@ -1,3 +1,7 @@
+## Version 0.10.0 (Version compatible with elasticsearch 6.8.1)
+## New Features
+This is the release of the Open Distro Performance Analyzer that will work with elasticsearch 6.8.1
+
 ## Version 0.9.0 (Version compatible with elasticsearch 6.7.1)
 ## New Features
 This is the release of the Open Distro Performance Analyzer that will work with elasticsearch 6.7.1


### PR DESCRIPTION
1. Updated elasticsearch version from 6.7.1 to 6.8.0
2. Updated opendistroversion from 0.9.0 to 0.10.0
3. Updated release notes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
