### PR TITLE
Bug Fixes -

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/PerformanceAnalyzerMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/PerformanceAnalyzerMetrics.java
@@ -81,10 +81,7 @@ public class PerformanceAnalyzerMetrics {
     }
 
     public static String generatePath(long startTime, String... keysPath) {
-	Path sDevShmLocationPath = Paths.get(sDevShmLocation).resolve(String.valueOf(PerformanceAnalyzerMetrics.getTimeInterval(startTime)));
-        for (String key: keysPath) {
-            sDevShmLocationPath = sDevShmLocationPath.resolve(key);
-        }
+	Path sDevShmLocationPath = Paths.get(sDevShmLocation).resolve(Paths.get(String.valueOf(PerformanceAnalyzerMetrics.getTimeInterval(startTime)), keysPath));
         return sDevShmLocationPath.toString();
     }
 
@@ -166,15 +163,7 @@ public class PerformanceAnalyzerMetrics {
     }
 
     public static String getMetric(long startTime, String... keysPath) {
-        StringBuilder stringBuilder = new StringBuilder(sDevShmLocation);
-
-        stringBuilder.append(String.valueOf(PerformanceAnalyzerMetrics.getTimeInterval(startTime))).append(File.separator);
-
-        for (String key: keysPath) {
-            stringBuilder.append(File.separator).append(key);
-        }
-
-        return getMetric(stringBuilder.toString());
+	return getMetric(generatePath(startTime, keysPath));
     }
 
     public static String getMetric(String keyPath) {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/PerformanceAnalyzerMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/PerformanceAnalyzerMetrics.java
@@ -82,7 +82,13 @@ public class PerformanceAnalyzerMetrics {
     public static String generatePath(long startTime, String... keysPath) {
         StringBuilder stringBuilder = new StringBuilder(sDevShmLocation);
 
-        stringBuilder.append(String.valueOf(PerformanceAnalyzerMetrics.getTimeInterval(startTime))).append(File.separator);
+        char lastChar = stringBuilder.charAt(stringBuilder.length() - 1);
+        if (lastChar == File.separatorChar) {
+            stringBuilder.append(String.valueOf(PerformanceAnalyzerMetrics.getTimeInterval(startTime))).append(File.separator);
+        }
+        else {
+            stringBuilder.append(File.separator).append(String.valueOf(PerformanceAnalyzerMetrics.getTimeInterval(startTime))).append(File.separator);
+        }
 
         for (String key: keysPath) {
             stringBuilder.append(File.separator).append(key);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/PerformanceAnalyzerMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/PerformanceAnalyzerMetrics.java
@@ -19,6 +19,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 
 import org.apache.logging.log4j.LogManager;
@@ -80,21 +81,11 @@ public class PerformanceAnalyzerMetrics {
     }
 
     public static String generatePath(long startTime, String... keysPath) {
-        StringBuilder stringBuilder = new StringBuilder(sDevShmLocation);
-
-        char lastChar = stringBuilder.charAt(stringBuilder.length() - 1);
-        if (lastChar == File.separatorChar) {
-            stringBuilder.append(String.valueOf(PerformanceAnalyzerMetrics.getTimeInterval(startTime))).append(File.separator);
-        }
-        else {
-            stringBuilder.append(File.separator).append(String.valueOf(PerformanceAnalyzerMetrics.getTimeInterval(startTime))).append(File.separator);
-        }
-
+	Path sDevShmLocationPath = Paths.get(sDevShmLocation).resolve(String.valueOf(PerformanceAnalyzerMetrics.getTimeInterval(startTime)));
         for (String key: keysPath) {
-            stringBuilder.append(File.separator).append(key);
+            sDevShmLocationPath = sDevShmLocationPath.resolve(key);
         }
-
-        return stringBuilder.toString();
+        return sDevShmLocationPath.toString();
     }
 
     public static void addMetricEntry(StringBuilder value, String metricKey, String metricValue) {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metricsdb/MetricsDB.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metricsdb/MetricsDB.java
@@ -20,6 +20,8 @@ import java.sql.Connection;
 import java.sql.DriverManager;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.HashSet;
+import java.util.Arrays;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -68,6 +70,7 @@ public class MetricsDB implements Removable {
     public static final String AVG = "avg";
     public static final String MIN = "min";
     public static final String MAX = "max";
+    public static final HashSet<String> AGG_VALUES = new HashSet<>(Arrays.asList(SUM, AVG, MIN, MAX));
     private long windowStartTime;
 
     public String getDBFilePath() {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryMetricsRequestHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryMetricsRequestHandler.java
@@ -188,12 +188,13 @@ public class QueryMetricsRequestHandler extends MetricsHandler implements HttpHa
                 }
             }
         }
-        for (String agg: aggList) {
-            if (!agg.equals("sum") && !agg.equals("avg") && !agg.equals("min") && !agg.equals("max")) {
+	for (String agg : aggList) {
+            if (!MetricsDB.AGG_VALUES.contains(agg)) {
                 sendResponse(exchange, String.format("{\"error\":\"%s is an invalid aggregation type.\"}", agg), HttpURLConnection.HTTP_BAD_REQUEST);
                 return false;
             }
         }
+
         return true;
     }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryMetricsRequestHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/rest/QueryMetricsRequestHandler.java
@@ -117,13 +117,23 @@ public class QueryMetricsRequestHandler extends MetricsHandler implements HttpHa
                     return;
                 }
 
-                if (!validParams(exchange, metricList, dimList)) {
+                if (!validParams(exchange, metricList, dimList, aggList)) {
                     return;
                 }
 
                 String nodes = params.get("nodes");
                 String response = collectStats(db, dbTimestamp, metricList, aggList, dimList, nodes);
                 sendResponse(exchange, response, HttpURLConnection.HTTP_OK);
+            } catch (InvalidParameterException e) {
+                LOG.error("DB file path : {}", db.getDBFilePath());
+                LOG.error(
+                        (Supplier<?>) () -> new ParameterizedMessage(
+                                "QueryException {} ExceptionCode: {}.",
+                                e.toString(), StatExceptionCode.REQUEST_ERROR.toString()),
+                        e);
+                StatsCollector.instance().logException(StatExceptionCode.REQUEST_ERROR);
+                String response = "{\"error\":\"" + e.getMessage() + "\"}";
+                sendResponse(exchange, response, HttpURLConnection.HTTP_BAD_REQUEST);
             } catch (Exception e) {
                 LOG.error("DB file path : {}", db.getDBFilePath());
                 LOG.error(
@@ -158,7 +168,7 @@ public class QueryMetricsRequestHandler extends MetricsHandler implements HttpHa
         sendResponse(exchange, JsonConverter.writeValueAsString(metricUnits), HttpURLConnection.HTTP_OK);
     }
 
-    public boolean validParams(HttpExchange exchange, List<String> metricList, List<String> dimList)
+    public boolean validParams(HttpExchange exchange, List<String> metricList, List<String> dimList, List<String> aggList)
             throws IOException {
         for (String metric : metricList) {
             if (MetricsModel.ALL_METRICS.get(metric) == null) {
@@ -176,6 +186,12 @@ public class QueryMetricsRequestHandler extends MetricsHandler implements HttpHa
                         return false;
                     }
                 }
+            }
+        }
+        for (String agg: aggList) {
+            if (!agg.equals("sum") && !agg.equals("avg") && !agg.equals("min") && !agg.equals("max")) {
+                sendResponse(exchange, String.format("{\"error\":\"%s is an invalid aggregation type.\"}", agg), HttpURLConnection.HTTP_BAD_REQUEST);
+                return false;
             }
         }
         return true;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/PerformanceAnalyzerMetricsTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/PerformanceAnalyzerMetricsTests.java
@@ -15,12 +15,32 @@
 
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSettings;
 
 import static org.junit.Assert.assertEquals;
 import org.junit.Test;
+import org.junit.Before;
+import static org.mockito.Mockito.when;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
+import org.junit.runner.RunWith;
+import org.powermock.modules.junit4.PowerMockRunner;
 
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({ PerformanceAnalyzerMetrics.class, PluginSettings.class })
+@SuppressStaticInitializationFor({ "PluginSettings" })
 public class PerformanceAnalyzerMetricsTests {
 
+    @Before
+    public void setUp() throws Exception {
+        PluginSettings config = Mockito.mock(PluginSettings.class);
+        Mockito.when(config.getMetricsLocation()).thenReturn("dev/shm/performanceanalyzer");
+        PowerMockito.mockStatic(PluginSettings.class);
+        PowerMockito.when(PluginSettings.instance()).thenReturn(config);
+    }
 
     @Test
     public void testBasicMetric() {
@@ -31,5 +51,13 @@ public class PerformanceAnalyzerMetricsTests {
         assertEquals("", PerformanceAnalyzerMetrics.getMetric(PerformanceAnalyzerMetrics.sDevShmLocation + "/dir1/test2"));
 
         PerformanceAnalyzerMetrics.removeMetrics(PerformanceAnalyzerMetrics.sDevShmLocation + "/dir1");
+    }
+
+    @Test
+    public void testGeneratePath() {
+        long startTimeInMillis = 1553725339;
+        String generatedPath = PerformanceAnalyzerMetrics.generatePath(startTimeInMillis, "dir1", "id", "dir2");
+        String expectedPath = PerformanceAnalyzerMetrics.sDevShmLocation + "/" + String.valueOf(PerformanceAnalyzerMetrics.getTimeInterval(startTimeInMillis)) + "/dir1/id/dir2";
+        assertEquals(expectedPath, generatedPath);
     }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/PerformanceAnalyzerMetricsTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/metrics/PerformanceAnalyzerMetricsTests.java
@@ -26,9 +26,11 @@ import org.mockito.Mockito;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
+import org.powermock.core.classloader.annotations.PowerMockIgnore;
 import org.junit.runner.RunWith;
 import org.powermock.modules.junit4.PowerMockRunner;
 
+@PowerMockIgnore({ "org.apache.logging.log4j.*" })
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({ PerformanceAnalyzerMetrics.class, PluginSettings.class })
 @SuppressStaticInitializationFor({ "PluginSettings" })
@@ -37,7 +39,7 @@ public class PerformanceAnalyzerMetricsTests {
     @Before
     public void setUp() throws Exception {
         PluginSettings config = Mockito.mock(PluginSettings.class);
-        Mockito.when(config.getMetricsLocation()).thenReturn("dev/shm/performanceanalyzer");
+        Mockito.when(config.getMetricsLocation()).thenReturn("/dev/shm/performanceanalyzer");
         PowerMockito.mockStatic(PluginSettings.class);
         PowerMockito.when(PluginSettings.instance()).thenReturn(config);
     }


### PR DESCRIPTION
1. Returning status code 400 instead of 500 for the following client side errors -
     - When the client does not set the required parameters
     - When the client specifies an unknown aggregation type

2. Creating PA events in correct location even if metrics location config value doesn't have a trailing "/"

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
