### PR TITLE
Allow PA to be en/disabled through cluster settings

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/ESResources.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/ESResources.java
@@ -14,6 +14,7 @@
  */
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer;
+import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.service.ClusterService;
 import org.elasticsearch.indices.breaker.CircuitBreakerService;
 import org.elasticsearch.threadpool.ThreadPool;
@@ -32,6 +33,7 @@ public final class ESResources {
     private Environment environment;
     private java.nio.file.Path configPath;
     private String pluginFileLocation;
+    private Client client;
 
     private ESResources() {
         threadPool = null;
@@ -106,5 +108,13 @@ public final class ESResources {
 
     public void setIndicesService(IndicesService indicesService) {
         this.indicesService = indicesService;
+    }
+
+    public void setClient(final Client client) {
+        this.client = client;
+    }
+
+    public Client getClient() {
+        return client;
     }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/SettingsHelper.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/SettingsHelper.java
@@ -16,22 +16,34 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.config;
 
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.ESResources;
-
-import java.io.InputStream;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Properties;
 
+import org.elasticsearch.common.settings.Setting;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.ESResources;
+
 public class SettingsHelper {
+    private static final Setting<Boolean> PERFORMANCE_ANALYZER_CLUSTER_SETTING = Setting.boolSetting(
+            "cluster.metadata.performance_analyzer.enabled",
+            false,
+            Setting.Property.Dynamic,
+            Setting.Property.NodeScope);
+
     public static Properties getSettings(final String fileRelativePath) throws IOException {
         Properties prop = new Properties();
 
-        try (InputStream input = new FileInputStream(ESResources.INSTANCE.getPluginFileLocation() + fileRelativePath); ) {
+        try (InputStream input = new FileInputStream(ESResources.INSTANCE.getPluginFileLocation() + fileRelativePath);) {
             // load a properties file
             prop.load(input);
         }
 
         return prop;
+    }
+
+    public static Setting<Boolean> getPerformanceAnalyzerClusterSetting() {
+        return PERFORMANCE_ANALYZER_CLUSTER_SETTING;
     }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/http_action/config/PerformanceAnalyzerConfigAction.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/http_action/config/PerformanceAnalyzerConfigAction.java
@@ -15,41 +15,53 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.http_action.config;
 
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerPlugin;
-import org.elasticsearch.rest.BaseRestHandler;
-import org.elasticsearch.rest.RestController;
-import org.elasticsearch.rest.RestRequest;
-import org.elasticsearch.rest.RestStatus;
-import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.client.node.NodeClient;
-
-import org.elasticsearch.common.xcontent.XContentBuilder;
-import org.elasticsearch.common.xcontent.XContentHelper;
-import org.elasticsearch.rest.BytesRestResponse;
-
-import java.io.IOException;
-import java.nio.file.Path;
-import java.util.Map;
-import java.nio.file.Files;
-import java.nio.file.Paths;
 import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Map;
 import java.util.Scanner;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.ActionListener;
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsRequest;
+import org.elasticsearch.action.admin.cluster.settings.ClusterUpdateSettingsResponse;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateRequest;
+import org.elasticsearch.action.admin.cluster.state.ClusterStateResponse;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.cluster.ClusterChangedEvent;
+import org.elasticsearch.cluster.ClusterStateListener;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentBuilder;
+import org.elasticsearch.common.xcontent.XContentHelper;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.BytesRestResponse;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestStatus;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.ConfigStatus;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.ESResources;
-import org.elasticsearch.common.inject.Inject;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerPlugin;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.SettingsHelper;
 
 @SuppressWarnings("deprecation")
 public class PerformanceAnalyzerConfigAction extends BaseRestHandler {
     private boolean featureEnabled;
     private static final Logger LOG = LogManager.getLogger(PerformanceAnalyzerConfigAction.class);
     private static final String ENABLED = "enabled";
+    private static final String PA_ENABLED_CLUSTER_SETTING_PATH = "/_opendistro/_performanceanalyzer/cluster/config";
+    private static final String CURRENT = "current";
+    private static final String DESIRED = "desired";
     private static PerformanceAnalyzerConfigAction instance = null;
     private boolean isInitialized = false;
-    private boolean featureEanbledDefaultValue = true;
+    private boolean featureEnabledDefaultValue = true;
+    private ActionListener<ClusterStateResponse> clusterStateResponseHandler = new ClusterStateResponseHandler();
+    private ActionListener<ClusterUpdateSettingsResponse> clusterUpdateSettingsResponseHandler = new ClusterUpdateSettingsResponseHandler();
+    private ClusterStateListener clusterStateListener = new ClusterStateUpdateListener();
 
     public static PerformanceAnalyzerConfigAction getInstance() {
         return instance;
@@ -60,12 +72,19 @@ public class PerformanceAnalyzerConfigAction extends BaseRestHandler {
     }
 
     private static final String METRIC_ENABLED_CONF_FILENAME = "performance_analyzer_enabled.conf";
+
     @Inject
     public PerformanceAnalyzerConfigAction(Settings settings, RestController controller) {
         super(settings);
         controller.registerHandler(org.elasticsearch.rest.RestRequest.Method.GET, "/_opendistro/_performanceanalyzer/config", this);
         controller.registerHandler(org.elasticsearch.rest.RestRequest.Method.POST, "/_opendistro/_performanceanalyzer/config", this);
+
+        controller.registerHandler(RestRequest.Method.POST, PA_ENABLED_CLUSTER_SETTING_PATH, this);
+        controller.registerHandler(RestRequest.Method.GET, PA_ENABLED_CLUSTER_SETTING_PATH, this);
+
         this.featureEnabled = getFeatureEnabledFromConf();
+        getFeatureEnabledFromClusterSettings();
+        registerClusterUpdateSettingsListener();
         LOG.info("PerformanceAnalyzer Enabled: {}", this.featureEnabled);
     }
 
@@ -75,14 +94,33 @@ public class PerformanceAnalyzerConfigAction extends BaseRestHandler {
             // Let's try to find the name from the body
             Map<String, Object> map = XContentHelper.convertToMap(request.content(), false).v2();
             Object value = map.get(ENABLED);
-            LOG.debug("PerformanceAnalyzer:Value (Object) Received as Part of Request: {} current value:", this.featureEnabled);
-            if (value != null && value instanceof Boolean) {
-                boolean bValue = (Boolean) value;
-                LOG.debug("PerformanceAnalyzer:Value (Boolean) Received as Part of Request: {}  current value: {}",
-                        bValue, this.featureEnabled);
-                if (this.featureEnabled != bValue) {
-                    this.featureEnabled = (Boolean) value;
-                    saveFeatureEnabledToConf(this.featureEnabled);
+            if (request.path().startsWith(PA_ENABLED_CLUSTER_SETTING_PATH)) {
+                if (value instanceof Boolean) {
+                    boolean bValue = (Boolean) value;
+                    updatePerformanceAnalyzerClusterSetting(bValue);
+                    return channel -> {
+                        try {
+                            XContentBuilder builder = channel.newBuilder();
+                            builder.startObject();
+                            builder.field(CURRENT, this.featureEnabled);
+                            builder.field(DESIRED, bValue);
+                            builder.endObject();
+                            channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
+                        } catch (IOException ioe) {
+                            LOG.error("Error sending response", ioe);
+                        }
+                    };
+                }
+            } else {
+                LOG.debug("PerformanceAnalyzer:Value (Object) Received as Part of Request: {} current value:", this.featureEnabled);
+                if (value instanceof Boolean) {
+                    boolean bValue = (Boolean) value;
+                    LOG.debug("PerformanceAnalyzer:Value (Boolean) Received as Part of Request: {}  current value: {}",
+                            bValue, this.featureEnabled);
+                    if (this.featureEnabled != bValue) {
+                        this.featureEnabled = (Boolean) value;
+                        saveFeatureEnabledToConf(this.featureEnabled);
+                    }
                 }
             }
         }
@@ -114,7 +152,8 @@ public class PerformanceAnalyzerConfigAction extends BaseRestHandler {
     }
 
     private String getDataDirectory() {
-        return new org.elasticsearch.env.Environment(ESResources.INSTANCE.getSettings(),
+        return new org.elasticsearch.env.Environment(
+                ESResources.INSTANCE.getSettings(),
                 ESResources.INSTANCE.getConfigPath()).dataFiles()[0].toFile().getPath();
     }
 
@@ -124,7 +163,7 @@ public class PerformanceAnalyzerConfigAction extends BaseRestHandler {
                 Files.write(
                         Paths.get(getDataDirectory() + File.separator + METRIC_ENABLED_CONF_FILENAME),
                         String.valueOf(featureEnabled).getBytes());
-            } catch(Exception ex) {
+            } catch (Exception ex) {
                 LOG.error(ex.toString(), ex);
             }
         });
@@ -139,15 +178,153 @@ public class PerformanceAnalyzerConfigAction extends BaseRestHandler {
                 featureEnabled = Boolean.parseBoolean(nextLine);
                 isInitialized = true;
             } catch (java.nio.file.NoSuchFileException ex) {
-                saveFeatureEnabledToConf(featureEanbledDefaultValue);
+                saveFeatureEnabledToConf(featureEnabledDefaultValue);
                 isInitialized = true;
-                featureEnabled = featureEanbledDefaultValue;
+                featureEnabled = featureEnabledDefaultValue;
             } catch (Exception e) {
                 LOG.error("Error reading Feature Enabled from Conf file", e);
-                featureEnabled = featureEanbledDefaultValue;
+                featureEnabled = featureEnabledDefaultValue;
             }
         });
         return featureEnabled;
     }
 
+    private void updatePerformanceAnalyzerClusterSetting(final Boolean value) {
+        final ClusterUpdateSettingsRequest clusterUpdateSettingsRequest = new ClusterUpdateSettingsRequest();
+        clusterUpdateSettingsRequest.persistentSettings(Settings.builder()
+                                                                .put(SettingsHelper.getPerformanceAnalyzerClusterSetting().getKey(), value)
+                                                                .build());
+
+        ESResources.INSTANCE.getClient()
+                            .admin()
+                            .cluster()
+                            .updateSettings(clusterUpdateSettingsRequest, clusterUpdateSettingsResponseHandler);
+    }
+
+    private void registerClusterUpdateSettingsListener() {
+        ESResources.INSTANCE.getClusterService()
+                            .getClusterSettings()
+                            .addSettingsUpdateConsumer(
+                                    SettingsHelper.getPerformanceAnalyzerClusterSetting(),
+                                    isEnabled -> {
+                                        this.featureEnabled = isEnabled;
+                                        saveFeatureEnabledToConf(isEnabled);
+                                    });
+    }
+
+    private void getFeatureEnabledFromClusterSettings() {
+        try {
+            final ClusterStateRequest clusterStateRequest = new ClusterStateRequest();
+            clusterStateRequest.routingTable(false)
+                               .nodes(false);
+
+            ESResources.INSTANCE.getClient()
+                                .admin()
+                                .cluster()
+                                .state(clusterStateRequest, clusterStateResponseHandler);
+        } catch (Exception | AssertionError e) {
+            LOG.warn("Unable to retrieve cluster metadata at this time. Re-registering listener. {}", e.getMessage());
+            registerClusterStateUpdateHandler();
+        }
+    }
+
+    private void registerClusterStateUpdateHandler() {
+        ESResources.INSTANCE.getClusterService().addListener(clusterStateListener);
+    }
+
+    private void updateFeatureEnabled(final ClusterStateResponse clusterStateResponse) {
+        this.featureEnabled = clusterStateResponse.getState()
+                                                  .getMetaData()
+                                                  .persistentSettings()
+                                                  .getAsBoolean(SettingsHelper.getPerformanceAnalyzerClusterSetting()
+                                                                              .getKey(), false);
+        saveFeatureEnabledToConf(featureEnabled);
+    }
+
+    private void updateFeatureEnabled(final ClusterUpdateSettingsResponse clusterUpdateSettingsResponse) {
+        if (clusterUpdateSettingsResponse.isAcknowledged()) {
+            this.featureEnabled = clusterUpdateSettingsResponse.getPersistentSettings()
+                                                               .getAsBoolean(SettingsHelper.getPerformanceAnalyzerClusterSetting()
+                                                                                           .getKey(), false);
+            saveFeatureEnabledToConf(featureEnabled);
+        } else {
+            LOG.debug("Cluster setting update was not acknowledged. Not applying the update.");
+        }
+    }
+
+    /**
+     * Class that listens to cluster state changes. Used only during initialization
+     * when the plugin is started before a cluster state is set and we need to query
+     * the cluster settings to fetch PA setting for the first time.
+     */
+    private class ClusterStateUpdateListener implements ClusterStateListener {
+
+        /**
+         * Called when cluster state changes.
+         * Attempt to read cluster settings.
+         *
+         * @param event Cluster changed event.
+         */
+        @Override
+        public void clusterChanged(final ClusterChangedEvent event) {
+            ESResources.INSTANCE.getClusterService().removeListener(clusterStateListener);
+            getFeatureEnabledFromClusterSettings();
+        }
+    }
+
+    /**
+     * Class that handles the response to GET /_cluster/settings request.
+     */
+    private class ClusterStateResponseHandler implements ActionListener<ClusterStateResponse> {
+
+        /**
+         * Handle action response. This response may constitute a failure or a
+         * success but it is up to the listener to make that decision.
+         *
+         * @param clusterStateResponse The response that contains settings and cluster metadata.
+         */
+        @Override
+        public void onResponse(final ClusterStateResponse clusterStateResponse) {
+            ESResources.INSTANCE.getClusterService().removeListener(clusterStateListener);
+            updateFeatureEnabled(clusterStateResponse);
+        }
+
+        /**
+         * A failure caused by an exception at some phase of the task.
+         *
+         * @param e
+         */
+        @Override
+        public void onFailure(final Exception e) {
+            registerClusterStateUpdateHandler();
+            LOG.warn("Unable fetch cluster settings. Exception: {}", e.getMessage());
+        }
+    }
+
+    /**
+     * Class that handles response to POST /_cluster/settings request.
+     */
+    private class ClusterUpdateSettingsResponseHandler implements ActionListener<ClusterUpdateSettingsResponse> {
+
+        /**
+         * Handle action response. This response may constitute a failure or a
+         * success but it is up to the listener to make that decision.
+         *
+         * @param clusterUpdateSettingsResponse Response from the cluster applier service.
+         */
+        @Override
+        public void onResponse(final ClusterUpdateSettingsResponse clusterUpdateSettingsResponse) {
+            updateFeatureEnabled(clusterUpdateSettingsResponse);
+        }
+
+        /**
+         * A failure caused by an exception at some phase of the task.
+         *
+         * @param e
+         */
+        @Override
+        public void onFailure(final Exception e) {
+            LOG.warn("Unable to update cluster setting. Exception: {}", e.getMessage());
+        }
+    }
 }


### PR DESCRIPTION
Currently, we can only enable or disable Performance Analyzer on a per-node basis. This makes enabling or disabling PerformanceAnalyzer hard for larger clusters.

This change adds a cluster metadata key to the cluster settings that can be used to indicate PA enabled state. A new endpoint /_opendistro/_performanceanalyzer/cluster/config is also exposed which can be POSTed to with true/false to enable or disable performance analyzer across the cluster.

Since the metadata is added as a persistent setting, the enabled/disabled state is also persisted across restarts. Whenever a new node is spun up, it reads the value from the cluster settings and updates PA state locally.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.