### PR TITLE
Adding shardsPerCollection REST API to update the shards Per Collection in Node Stats collector

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -173,7 +173,8 @@ bundlePlugin {
 
 gradle.startParameter.excludedTaskNames += [ "forbiddenApisMain",
                                              "forbiddenApisTest",
-                                             "thirdPartyAudit", "testingConventions"]
+                                             "thirdPartyAudit",
+                                             "testingConventions"]
 
 // This is afterEvaluate because the bundlePlugin ZIP task is updated afterEvaluate and changes the ZIP name to match the plugin name
 afterEvaluate {
@@ -214,7 +215,7 @@ afterEvaluate {
         maintainer 'OpenDistro for Elasticsearch Team <opendistro@amazon.com>'
         url 'https://opendistro.github.io/elasticsearch/downloads'
         summary '''
-         Performance Analyzer plugin for OpenDistro for Elasticsearch. 
+         Performance Analyzer plugin for OpenDistro for Elasticsearch.
          Reference documentation can be found at https://opendistro.github.io/elasticsearch/docs.
     '''.stripIndent().replace('\n', ' ').trim()
     }
@@ -232,7 +233,7 @@ afterEvaluate {
         archiveName "${packageName}-${version}.deb"
         dependsOn 'assemble'
     }
-    
+
     task buildPackages(type: GradleBuild) {
          tasks = ['build', 'buildRpm', 'buildDeb']
     }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/NodeStatsMetricsCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/NodeStatsMetricsCollector.java
@@ -18,17 +18,16 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors;
 import java.lang.reflect.Field;
 import java.util.EnumSet;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PerformanceAnalyzerController;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+import org.elasticsearch.action.admin.indices.stats.CommonStats;
 import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags;
 import org.elasticsearch.action.admin.indices.stats.IndexShardStats;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
-import org.elasticsearch.index.Index;
 import org.elasticsearch.index.IndexService;
 import org.elasticsearch.index.shard.IndexShard;
 import org.elasticsearch.index.shard.IndexShardState;
@@ -51,13 +50,20 @@ public class NodeStatsMetricsCollector extends PerformanceAnalyzerMetricsCollect
     public static final int SAMPLING_TIME_INTERVAL = MetricsConfiguration.CONFIG_MAP.get(NodeStatsMetricsCollector.class).samplingInterval;
     private static final int KEYS_PATH_LENGTH = 2;
     private static final Logger LOG = LogManager.getLogger(NodeStatsMetricsCollector.class);
-    private HashMap<ShardId, CachedStats> cachedInfo;
-    private HashMap<ShardId, IndexShard> currentShards;
+    private HashMap<String, IndexShard> currentShards;
+    private Iterator<HashMap.Entry<String, IndexShard>> currentShardsIter;
+    private final PerformanceAnalyzerController controller;
 
-    public NodeStatsMetricsCollector() {
+
+    public NodeStatsMetricsCollector(final PerformanceAnalyzerController controller) {
         super(SAMPLING_TIME_INTERVAL, "NodeStatsMetrics");
-        cachedInfo = new HashMap<>();
         currentShards = new HashMap<>();
+        currentShardsIter = currentShards.entrySet().iterator();
+        this.controller = controller;
+    }
+
+    private String getUniqueShardIdKey(ShardId shardId) {
+        return "[" + shardId.getIndex().getUUID() + "][" + shardId.getId() + "]";
     }
 
     private void populateCurrentShards() {
@@ -67,9 +73,34 @@ public class NodeStatsMetricsCollector extends PerformanceAnalyzerMetricsCollect
             Iterator<IndexShard> indexShards = indexServices.next().iterator();
             while (indexShards.hasNext()) {
                 IndexShard shard = indexShards.next();
-                currentShards.put(shard.shardId(), shard);
+                currentShards.put(getUniqueShardIdKey(shard.shardId()), shard);
             }
         }
+        currentShardsIter = currentShards.entrySet().iterator();
+    }
+
+    /**
+     * This function is copied directly from IndicesService.java in elastic search as the original function is not public
+     * we need to collect stats per shard based instead of calling the stat() function to fetch all at once(which increases
+     * cpu usage on data nodes dramatically).
+     */
+    private IndexShardStats indexShardStats(final IndicesService indicesService, final IndexShard indexShard,
+                                            final CommonStatsFlags flags) {
+        if (indexShard.routingEntry() == null) {
+            return null;
+        }
+
+        return new IndexShardStats(
+                indexShard.shardId(),
+                new ShardStats[]{
+                        new ShardStats(
+                                indexShard.routingEntry(),
+                                indexShard.shardPath(),
+                                new CommonStats(indicesService.getIndicesQueryCache(), indexShard, flags),
+                                null,
+                                null,
+                                null)
+                });
     }
 
     private static final EnumSet<IndexShardState> CAN_WRITE_INDEX_BUFFER_STATES = EnumSet.of(
@@ -123,7 +154,7 @@ public class NodeStatsMetricsCollector extends PerformanceAnalyzerMetricsCollect
     } };
 
     private long getIndexBufferBytes(ShardStats shardStats) {
-        IndexShard shard = currentShards.get(shardStats.getShardRouting().shardId());
+        IndexShard shard = currentShards.get(getUniqueShardIdKey(shardStats.getShardRouting().shardId()));
 
         if (shard == null) {
             return 0;
@@ -151,52 +182,34 @@ public class NodeStatsMetricsCollector extends PerformanceAnalyzerMetricsCollect
         if (indicesService == null) {
             return;
         }
-
-        NodeIndicesStats nodeIndicesStats = indicesService.stats(true, CommonStatsFlags.ALL);
-
-        HashSet<ShardId> currentShards = new HashSet<>();
-
+        
         try {
-            populateCurrentShards();
-            Map<Index, List<IndexShardStats>> statsByShard =
-                    (Map<Index, List<IndexShardStats>>) getNodeIndicesStatsByShardField().get(nodeIndicesStats);
+            //reach the end of current shardId list. retrieve new shard list from IndexService
+            if (!currentShardsIter.hasNext()) {
+                populateCurrentShards();
+            }
+            for(int i = 0; i < controller.getNodeStatsShardsPerCollection(); i++){
+                if (!currentShardsIter.hasNext()) {
+                    break;
+                }
+                IndexShard currentIndexShard = currentShardsIter.next().getValue();
+                IndexShardStats currentIndexShardStats = this.indexShardStats(indicesService, currentIndexShard, CommonStatsFlags.ALL);
+                for (ShardStats shardStats : currentIndexShardStats.getShards()) {
+                    StringBuilder value = new StringBuilder();
 
-            for (List<IndexShardStats> shardStatsList : statsByShard.values()) {
-                for (IndexShardStats indexShardStats : shardStatsList) {
-                    for (ShardStats shardStats : indexShardStats.getShards()) {
-                        currentShards.add(indexShardStats.getShardId());
+                    value.append(PerformanceAnalyzerMetrics.getJsonCurrentMilliSeconds());
+                    //- go through the list of metrics to be collected and emit
+                    value.append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor)
+                            .append(new NodeStatsMetricsStatus(shardStats).serialize());
 
-                        if (!cachedInfo.containsKey(indexShardStats.getShardId())) {
-                            cachedInfo.put(indexShardStats.getShardId(), new CachedStats());
-                        }
-
-                        CachedStats prevStats = cachedInfo.get(indexShardStats.getShardId());
-
-                        StringBuilder value = new StringBuilder();
-
-                        value.append(PerformanceAnalyzerMetrics.getJsonCurrentMilliSeconds());
-                        //- go through the list of metrics to be collected and emit
-                        value.append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor)
-                                .append(new NodeStatsMetricsStatus(shardStats,
-                                        prevStats).serialize());
-
-                        saveMetricValues(value.toString(), startTime, indexShardStats.getShardId().getIndexName(),
-                                String.valueOf(indexShardStats.getShardId().id()));
-                    }
+                    saveMetricValues(value.toString(), startTime, currentIndexShardStats.getShardId().getIndexName(),
+                            String.valueOf(currentIndexShardStats.getShardId().id()));
                 }
             }
         } catch (Exception ex) {
             LOG.debug("Exception in Collecting NodesStats Metrics: {} for startTime {} with ExceptionCode: {}",
                       () -> ex.toString(), () -> startTime, () -> StatExceptionCode.NODESTATS_COLLECTION_ERROR.toString());
             StatsCollector.instance().logException(StatExceptionCode.NODESTATS_COLLECTION_ERROR);
-        }
-
-        //- remove from Cache if IndexName/ShardId is not present anymore...this will keep the Sanity of Cache
-        for (Iterator<Map.Entry<ShardId, CachedStats>> it = cachedInfo.entrySet().iterator(); it.hasNext();) {
-            Map.Entry<ShardId, CachedStats> entry = it.next();
-            if (!currentShards.contains(entry.getKey())) {
-                it.remove();
-            }
         }
     }
 
@@ -211,9 +224,6 @@ public class NodeStatsMetricsCollector extends PerformanceAnalyzerMetricsCollect
 
         @JsonIgnore
         private ShardStats shardStats;
-
-        @JsonIgnore
-        private CachedStats prevStats;
 
         private final long indexingThrottleTime;
         private final long queryCacheHitCount;
@@ -245,11 +255,9 @@ public class NodeStatsMetricsCollector extends PerformanceAnalyzerMetricsCollect
         private final long versionMapMemory;
         private final long bitsetMemory;
 
-        public NodeStatsMetricsStatus(ShardStats shardStats,
-                CachedStats prevStats) {
+        public NodeStatsMetricsStatus(ShardStats shardStats) {
             super();
             this.shardStats = shardStats;
-            this.prevStats = prevStats;
 
             this.indexingThrottleTime = calculate(
                     ShardStatsValue.INDEXING_THROTTLE_TIME);
@@ -309,7 +317,6 @@ public class NodeStatsMetricsCollector extends PerformanceAnalyzerMetricsCollect
                 long bitsetMemory) {
             super();
             this.shardStats = null;
-            this.prevStats = null;
             this.indexingThrottleTime = indexingThrottleTime;
             this.queryCacheHitCount = queryCacheHitCount;
             this.queryCacheMissCount = queryCacheMissCount;
@@ -343,18 +350,12 @@ public class NodeStatsMetricsCollector extends PerformanceAnalyzerMetricsCollect
 
 
         private long calculate(ShardStatsValue nodeMetric) {
-            return valueCalculators.get(nodeMetric.toString()).calculate(
-                    shardStats, prevStats, nodeMetric.toString());
+            return valueCalculators.get(nodeMetric.toString()).calculateValue(shardStats);
         }
 
         @JsonIgnore
         public ShardStats getShardStats() {
             return shardStats;
-        }
-
-        @JsonIgnore
-        public CachedStats getPrevStats() {
-            return prevStats;
         }
 
         @JsonProperty(ShardStatsValue.Constants.INDEXING_THROTTLE_TIME_VALUE)

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ValueCalculator.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ValueCalculator.java
@@ -20,14 +20,4 @@ import org.elasticsearch.action.admin.indices.stats.ShardStats;
 @FunctionalInterface
 interface ValueCalculator {
     long calculateValue(ShardStats shardStats);
-
-    default long calculate(ShardStats shardStats, CachedStats cachedStats, String statsName) {
-        long calculatedVal = calculateValue(shardStats);
-        long cachedValue = 0;
-        if (CachedStats.getCachableValues().contains(statsName)) {
-            cachedValue = cachedStats.getValue(statsName);
-            cachedStats.putValue(statsName, calculatedVal);
-        }
-        return calculatedVal - cachedValue;
-    }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/setting/PerformanceAnalyzerClusterSettings.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/setting/PerformanceAnalyzerClusterSettings.java
@@ -21,4 +21,16 @@ public final class PerformanceAnalyzerClusterSettings {
         RCA_BIT,
         LOGGING_BIT
     }
+
+    /**
+     * node stats collector enabled/disabled
+     * less than or equal to 0 : disabled
+     * greater than 0 : enabled, and this set the number of shards per collection
+     */
+    public static final Setting<Integer> PA_NODE_STATS_SETTING = Setting.intSetting(
+            "cluster.metadata.perf_analyzer.pa_node_stats_setting",
+            1,
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+    );
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/setting/handler/NodeStatsSettingHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/setting/handler/NodeStatsSettingHandler.java
@@ -1,0 +1,52 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.config.setting.handler;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PerformanceAnalyzerController;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.setting.ClusterSettingListener;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.setting.ClusterSettingsManager;
+
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.config.setting.PerformanceAnalyzerClusterSettings.PA_NODE_STATS_SETTING;
+
+public class NodeStatsSettingHandler implements ClusterSettingListener<Integer> {
+    private final PerformanceAnalyzerController controller;
+    private final ClusterSettingsManager clusterSettingsManager;
+
+    private Integer currentClusterSetting = PerformanceAnalyzerController.DEFAULT_NUM_OF_SHARDS_PER_COLLECTION;
+
+    public NodeStatsSettingHandler(final PerformanceAnalyzerController controller,
+                                   final ClusterSettingsManager clusterSettingsManager) {
+        this.controller = controller;
+        this.clusterSettingsManager = clusterSettingsManager;
+    }
+
+
+    /**
+     * Updates the PA Node Stats setting across the cluster.
+     *
+     * @param value The desired num of shards value for node stats.
+     */
+    public void updateNodeStatsSetting(final int value) {
+        clusterSettingsManager.updateSetting(PA_NODE_STATS_SETTING, value);
+    }
+
+    /**
+     * Handler that gets called when there is a new value for the setting that this listener
+     * is listening to.
+     *
+     * @param newSettingValue The value of the new setting.
+     */
+    @Override
+    public void onSettingUpdate(final Integer newSettingValue) {
+        if (newSettingValue != null) {
+            currentClusterSetting = newSettingValue;
+            controller.updateNodeStatsShardsPerCollection(newSettingValue);
+        }
+    }
+
+    /**
+     * Gets the current(last seen) cluster setting value.
+     * @return integer value for setting.
+     */
+    public int getNodeStatsSetting() {
+        return currentClusterSetting;
+    }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/http_action/config/PerformanceAnalyzerConfigAction.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/http_action/config/PerformanceAnalyzerConfigAction.java
@@ -37,6 +37,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.Performanc
 public class PerformanceAnalyzerConfigAction extends BaseRestHandler {
     private static final Logger LOG = LogManager.getLogger(PerformanceAnalyzerConfigAction.class);
     private static final String ENABLED = "enabled";
+    private static final String SHARDS_PER_COLLECTION = "shardsPerCollection";
     private static final String PA_ENABLED = "performanceAnalyzerEnabled";
     private static final String RCA_ENABLED = "rcaEnabled";
     private static final String PA_LOGGING_ENABLED = "loggingEnabled";
@@ -106,6 +107,13 @@ public class PerformanceAnalyzerConfigAction extends BaseRestHandler {
                     performanceAnalyzerController.updatePerformanceAnalyzerState(shouldEnable);
                 }
             }
+            // update node stats setting if exists
+            if (map.containsKey(SHARDS_PER_COLLECTION)) {
+                Object shardPerCollectionValue = map.get(SHARDS_PER_COLLECTION);
+                if (shardPerCollectionValue instanceof Integer) {
+                    performanceAnalyzerController.updateNodeStatsShardsPerCollection((Integer)shardPerCollectionValue);
+                }
+            }
         }
 
         return channel -> {
@@ -115,6 +123,7 @@ public class PerformanceAnalyzerConfigAction extends BaseRestHandler {
                 builder.field(PA_ENABLED, performanceAnalyzerController.isPerformanceAnalyzerEnabled());
                 builder.field(RCA_ENABLED, performanceAnalyzerController.isRcaEnabled());
                 builder.field(PA_LOGGING_ENABLED, performanceAnalyzerController.isLoggingEnabled());
+                builder.field(SHARDS_PER_COLLECTION, performanceAnalyzerController.getNodeStatsShardsPerCollection());
                 builder.endObject();
                 channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
             } catch (IOException ioe) {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/http_action/config/PerformanceAnalyzerResourceProvider.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/http_action/config/PerformanceAnalyzerResourceProvider.java
@@ -1,0 +1,203 @@
+/*
+ * Copyright <2019> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.http_action.config;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSettings;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableSet;
+import java.io.InputStream;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.client.node.NodeClient;
+import org.elasticsearch.common.inject.Inject;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.rest.BaseRestHandler;
+import org.elasticsearch.rest.BytesRestResponse;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.elasticsearch.rest.RestResponse;
+import org.elasticsearch.rest.RestStatus;
+
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.security.KeyManagementException;
+import java.security.NoSuchAlgorithmException;
+import java.security.cert.X509Certificate;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+public class PerformanceAnalyzerResourceProvider extends BaseRestHandler {
+  private static final Logger LOG = LogManager.getLogger(PerformanceAnalyzerResourceProvider.class);
+
+  private static final int HTTP_CLIENT_CONNECTION_TIMEOUT_MILLIS = 200;
+  private static final String AGENT_PATH = "/_opendistro/_performanceanalyzer/_agent/";
+  private static final String DEFAULT_PORT_NUMBER = "9650";
+
+  private String portNumber;
+  private final boolean isHttpsEnabled;
+  private static Set<String> SUPPORTED_REDIRECTIONS = ImmutableSet.of("rca", "metrics");
+
+  @Inject
+  public PerformanceAnalyzerResourceProvider(Settings settings, RestController controller) {
+    super(settings);
+    controller.registerHandler(org.elasticsearch.rest.RestRequest.Method.GET, AGENT_PATH + "{redirectEndpoint}", this);
+    PluginSettings pluginSettings = PluginSettings.instance();
+    portNumber = pluginSettings.getSettingValue("webservice-listener-port", DEFAULT_PORT_NUMBER);
+    isHttpsEnabled = pluginSettings.getHttpsEnabled();
+
+    if (isHttpsEnabled) {
+      // skip host name verification
+      // Create a trust manager that does not validate certificate chains
+      TrustManager[] trustAllCerts = new TrustManager[]{
+              new X509TrustManager() {
+                public java.security.cert.X509Certificate[] getAcceptedIssuers() {
+                  return null;
+                }
+
+                public void checkClientTrusted(X509Certificate[] certs, String authType) {
+                }
+
+                public void checkServerTrusted(X509Certificate[] certs, String authType) {
+                }
+              }
+      };
+
+      // Install the all-trusting trust manager
+      try {
+        SSLContext sc = SSLContext.getInstance("SSL");
+        sc.init(null, trustAllCerts, new java.security.SecureRandom());
+        HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
+      } catch (NoSuchAlgorithmException e) {
+        LOG.error("Error encountered while initializing SSLContext", e);
+      } catch (KeyManagementException e) {
+        LOG.error("Error encountered while initializing SSLContext", e);
+      }
+
+      // Create all-trusting host name verifier
+      HostnameVerifier allHostsValid = (hostname, session) -> true;
+      // Install the all-trusting host verifier
+      HttpsURLConnection.setDefaultHostnameVerifier(allHostsValid);
+    }
+  }
+
+  public String getName() {
+    return "PerformanceAnalyzer_ResourceProvider";
+  }
+
+  @Override
+  protected RestChannelConsumer prepareRequest(RestRequest request, NodeClient client) throws IOException {
+    StringBuilder response = new StringBuilder();
+    String inputLine;
+    int responseCode;
+
+    URL url = getAgentUri(request);
+    // 'url' is null if no correct mapping for input uri is found
+    if (url == null) {
+      return channel -> {
+        RestResponse finalResponse = new BytesRestResponse(RestStatus.NOT_FOUND, "");
+        channel.sendResponse(finalResponse);
+      };
+    } else {
+      HttpURLConnection httpURLConnection = isHttpsEnabled ? createHttpsURLConnection(url) :
+          createHttpURLConnection(url);
+      //Build Response in buffer
+      responseCode = httpURLConnection.getResponseCode();
+      InputStream inputStream = (responseCode == HttpsURLConnection.HTTP_OK) ?
+          httpURLConnection.getInputStream() : httpURLConnection.getErrorStream();
+
+      try (BufferedReader in = new BufferedReader(new InputStreamReader(inputStream))) {
+        while ((inputLine = in.readLine()) != null) {
+          response.append(inputLine);
+        }
+        LOG.debug("Response received - {}", response);
+      } catch (Exception ex) {
+        LOG.error("Error receiving response for Request Uri {} - {}", request.uri(), ex);
+        return channel -> {
+          channel.sendResponse(new BytesRestResponse(RestStatus.INTERNAL_SERVER_ERROR,
+              "Encountered error possibly with downstream APIs"));
+        };
+      }
+
+      RestResponse finalResponse = new BytesRestResponse(RestStatus.fromCode(responseCode),
+          String.valueOf(response));
+      LOG.debug("finalResponse: {}", finalResponse);
+
+      return channel -> {
+        try {
+          Map<String, List<String>> map = httpURLConnection.getHeaderFields();
+          for (Map.Entry<String, List<String>> entry : map.entrySet()) {
+            finalResponse.addHeader(entry.getKey(), entry.getValue().toString());
+          }
+          //Send Response back to callee
+          channel.sendResponse(finalResponse);
+        } catch (Exception ex) {
+          LOG.error("Error sending response", ex);
+          channel.sendResponse(new BytesRestResponse(RestStatus.INTERNAL_SERVER_ERROR, "Something went wrong"));
+        }
+      };
+    }
+  }
+
+  private HttpURLConnection createHttpsURLConnection(URL url) throws IOException {
+    HttpsURLConnection httpsURLConnection = (HttpsURLConnection) url.openConnection();
+    httpsURLConnection.setConnectTimeout(HTTP_CLIENT_CONNECTION_TIMEOUT_MILLIS);
+    return httpsURLConnection;
+  }
+
+  private HttpURLConnection createHttpURLConnection(URL url) throws IOException {
+    HttpURLConnection httpURLConnection = (HttpURLConnection) url.openConnection();
+    httpURLConnection.setConnectTimeout(HTTP_CLIENT_CONNECTION_TIMEOUT_MILLIS);
+    return httpURLConnection;
+  }
+
+  @VisibleForTesting
+  void setPortNumber(String portNumber) {
+    this.portNumber = portNumber;
+  }
+
+  /**
+   * Get Agent URI mapping
+   *
+   * @param request : RestRequest as input with valid URI
+   * @return URI of target path
+   * @throws IOException for invalid URL
+   */
+  public URL getAgentUri(RestRequest request) throws IOException {
+    String redirectEndpoint = request.param("redirectEndpoint");
+    String urlScheme = isHttpsEnabled ? "https://" : "http://";
+    String redirectBasePath = urlScheme + "localhost:" + portNumber + "/_opendistro/_performanceanalyzer/";
+    // Need to register all params in ES request else es throws illegal_argument_exception
+    for (String key : request.params().keySet()) {
+      request.param(key);
+    }
+
+    // Add Handler whenever add new redirectAgent path
+    if (SUPPORTED_REDIRECTIONS.contains(redirectEndpoint)) {
+      String uri = String.format(redirectBasePath + request.uri().split(AGENT_PATH)[1]);
+      return new URL(uri);
+    }
+    return null;
+  }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/writer/EventLogQueueProcessor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/writer/EventLogQueueProcessor.java
@@ -1,11 +1,5 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.writer;
 
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PerformanceAnalyzerController;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.http_action.config.PerformanceAnalyzerConfigAction;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.Event;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.EventLogFileHandler;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CancellationException;
@@ -17,136 +11,137 @@ import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PerformanceAnalyzerController;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.http_action.config.PerformanceAnalyzerConfigAction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.Event;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.EventLogFileHandler;
+
 public class EventLogQueueProcessor {
+    private static final Logger LOG = LogManager.getLogger(
+            EventLogQueueProcessor.class);
 
-  private static final Logger LOG = LogManager.getLogger(
-      EventLogQueueProcessor.class);
+    private final ScheduledExecutorService writerExecutor =
+            Executors.newScheduledThreadPool(1);
+    private final EventLogFileHandler eventLogFileHandler;
+    private final long initialDelayMillis;
+    private final long purgePeriodicityMillis;
+    private final PerformanceAnalyzerController controller;
+    private long lastTimeBucket;
 
-  private final ScheduledExecutorService writerExecutor =
-      Executors.newScheduledThreadPool(1);
-  private final EventLogFileHandler eventLogFileHandler;
-  private final long initialDelayMillis;
-  private final long purgePeriodicityMillis;
-  private final PerformanceAnalyzerController controller;
-  private long lastTimeBucket;
+    public EventLogQueueProcessor(EventLogFileHandler eventLogFileHandler,
+                                  long initialDelayMillis,
+                                  long purgePeriodicityMillis,
+                                  PerformanceAnalyzerController controller) {
+        this.eventLogFileHandler = eventLogFileHandler;
+        this.initialDelayMillis = initialDelayMillis;
+        this.purgePeriodicityMillis = purgePeriodicityMillis;
+        this.lastTimeBucket = 0;
+        this.controller = controller;
+    }
 
-  public EventLogQueueProcessor(EventLogFileHandler eventLogFileHandler,
-      long initialDelayMillis,
-      long purgePeriodicityMillis,
-      PerformanceAnalyzerController controller) {
-    this.eventLogFileHandler = eventLogFileHandler;
-    this.initialDelayMillis = initialDelayMillis;
-    this.purgePeriodicityMillis = purgePeriodicityMillis;
-    this.lastTimeBucket = 0;
-    this.controller = controller;
-  }
+    public void scheduleExecutor() {
+        ScheduledFuture<?> futureHandle =
+                writerExecutor.scheduleAtFixedRate(this::purgeQueueAndPersist,
+                        // The initial delay is critical here. The collector threads
+                        // start immediately with the Plugin. This thread purges the
+                        // queue and writes data to file. So, it waits for one run of
+                        // the collectors to complete before it starts, so that the
+                        // queue has elements to drain.
+                        initialDelayMillis,
+                        purgePeriodicityMillis, TimeUnit.MILLISECONDS);
+        new Thread(() -> {
+            try {
+                futureHandle.get();
+            } catch (InterruptedException e) {
+                LOG.error("Scheduled execution was interrupted", e);
+            } catch (CancellationException e) {
+                LOG.warn("Watcher thread has been cancelled", e);
+            } catch (ExecutionException e) {
+                LOG.error("QueuePurger interrupted. Caused by ",
+                        e.getCause());
+            }
+        }).start();
+    }
 
-  public void scheduleExecutor() {
-    ScheduledFuture<?> futureHandle =
-        writerExecutor.scheduleAtFixedRate(this::purgeQueueAndPersist,
-            // The initial delay is critical here. The collector threads
-            // start immediately with the Plugin. This thread purges the
-            // queue and writes data to file. So, it waits for one run of
-            // the collectors to complete before it starts, so that the
-            // queue has elements to drain.
-            initialDelayMillis,
-            purgePeriodicityMillis, TimeUnit.MILLISECONDS);
-    new Thread(() -> {
-      try {
-        futureHandle.get();
-      } catch (InterruptedException e) {
-        LOG.error("Scheduled execution was interrupted", e);
-      } catch (CancellationException e) {
-        LOG.warn("Watcher thread has been cancelled", e);
-      } catch (ExecutionException e) {
-        LOG.error("QueuePurger interrupted. Caused by ",
-            e.getCause());
-      }
-    }).start();
-  }
+    // This executes every purgePeriodicityMillis interval.
+    public void purgeQueueAndPersist() {
+        // Return if the writer is not enabled.
+        if (PerformanceAnalyzerConfigAction.getInstance() == null) {
+            return;
+        } else if (!controller.isPerformanceAnalyzerEnabled()) {
+            // If PA is disabled, then we return as we don't want to generate
+            // new files. But we also want to drain the queue so that when it is
+            // enabled next, we don't have the current elements as they would be
+            // old.
+            if (PerformanceAnalyzerMetrics.metricQueue.size() > 0) {
+                List<Event> metrics = new ArrayList<>();
+                PerformanceAnalyzerMetrics.metricQueue.drainTo(metrics);
+                LOG.info("Performance Analyzer no longer enabled. Drained the" +
+                        "queue to remove stale data.");
+            }
+            return;
+        }
 
-  // This executes every purgePeriodicityMillis interval.
-  public void purgeQueueAndPersist() {
-    // Return if the writer is not enabled.
-    if (PerformanceAnalyzerConfigAction.getInstance() == null) {
-      return;
-    } else if (!controller.isPerformanceAnalyzerEnabled()) {
-      // If PA is disabled, then we return as we don't want to generate
-      // new files. But we also want to drain the queue so that when it is
-      // enabled next, we don't have the current elements as they would be
-      // old.
-      if (PerformanceAnalyzerMetrics.metricQueue.size() > 0) {
+        LOG.debug("Starting to purge the queue.");
         List<Event> metrics = new ArrayList<>();
         PerformanceAnalyzerMetrics.metricQueue.drainTo(metrics);
-        LOG.info("Performance Analyzer no longer enabled. Drained the" +
-            "queue to remove stale data.");
-      }
-      return;
+        LOG.debug("Queue draining successful.");
+
+        long currentTimeMillis = System.currentTimeMillis();
+
+        // Calculate the timestamp on the file. For example, lets say the
+        // purging started at time 12.5 then all the events between 5-10
+        // are written to a file with name 5.
+        long timeBucket = PerformanceAnalyzerMetrics.getTimeInterval(
+                currentTimeMillis, MetricsConfiguration.SAMPLING_INTERVAL) -
+                MetricsConfiguration.SAMPLING_INTERVAL;
+
+        // When we are trying to collect the metrics for the 5th-10th second,
+        // but doing that in the 12.5th second, there is a chance that a
+        // collector ran in the 11th second and pushed the metrics in the
+        // queue. This thread, should be able to filter them and write them
+        // to their appropriate file, which should be 10 and not 5.
+        long nextTimeBucket = timeBucket + MetricsConfiguration.SAMPLING_INTERVAL;
+
+        List<Event> currMetrics = new ArrayList<>();
+        List<Event> nextMetrics = new ArrayList<>();
+
+        for (Event entry : metrics) {
+            if (entry.epoch == timeBucket) {
+                currMetrics.add(entry);
+            } else if (entry.epoch == nextTimeBucket) {
+                nextMetrics.add(entry);
+            } else {
+                LOG.info("UNEXPECTED entry ({}) with epoch '{}' arrived" +
+                                " when the current bucket is '{}'",
+                        entry.key, entry.epoch, timeBucket);
+            }
+        }
+
+        LOG.debug("Start serializing and writing to file.");
+        writeAndRotate(currMetrics, timeBucket, currentTimeMillis);
+        if (!nextMetrics.isEmpty()) {
+            // The next bucket metrics don't need to be considered for
+            // rotation just yet. So, we just write them to the
+            // <nextTimeBucket>.tmp
+            eventLogFileHandler.writeTmpFile(nextMetrics, nextTimeBucket);
+        }
+        LOG.debug("Writing to disk complete.");
     }
 
-    LOG.info("Queue size {}",
-        PerformanceAnalyzerMetrics.metricQueue.size());
-
-    LOG.debug("Starting to purge the queue.");
-    List<Event> metrics = new ArrayList<>();
-    PerformanceAnalyzerMetrics.metricQueue.drainTo(metrics);
-    LOG.debug("Queue draining successful.");
-
-    long currentTimeMillis = System.currentTimeMillis();
-
-    // Calculate the timestamp on the file. For example, lets say the
-    // purging started at time 12.5 then all the events between 5-10
-    // are written to a file with name 5.
-    long timeBucket = PerformanceAnalyzerMetrics.getTimeInterval(
-        currentTimeMillis, MetricsConfiguration.SAMPLING_INTERVAL) -
-        MetricsConfiguration.SAMPLING_INTERVAL;
-
-    // When we are trying to collect the metrics for the 5th-10th second,
-    // but doing that in the 12.5th second, there is a chance that a
-    // collector ran in the 11th second and pushed the metrics in the
-    // queue. This thread, should be able to filter them and write them
-    // to their appropriate file, which should be 10 and not 5.
-    long nextTimeBucket = timeBucket + MetricsConfiguration.SAMPLING_INTERVAL;
-
-    List<Event> currMetrics = new ArrayList<>();
-    List<Event> nextMetrics = new ArrayList<>();
-
-    for (Event entry : metrics) {
-      if (entry.epoch == timeBucket) {
-        currMetrics.add(entry);
-      } else if (entry.epoch == nextTimeBucket) {
-        nextMetrics.add(entry);
-      } else {
-        LOG.info("UNEXPECTED entry ({}) with epoch '{}' arrived" +
-                " when the current bucket is '{}'",
-            entry.key, entry.epoch, timeBucket);
-      }
+    private void writeAndRotate(final List<Event> currMetrics,
+                                long currTimeBucket,
+                                long currentTime) {
+        // Going by the continuing example, we will rotate the 5.tmp file to
+        // 5, which contains the metrics with epoch 5-10, whenever the purger
+        // runs after the 15th second.
+        if (lastTimeBucket != 0 && lastTimeBucket != currTimeBucket) {
+            eventLogFileHandler.renameFromTmp(lastTimeBucket);
+        }
+        // This appends the data to a file named <currTimeBucket>.tmp
+        eventLogFileHandler.writeTmpFile(currMetrics, currTimeBucket);
+        lastTimeBucket = currTimeBucket;
     }
-    LOG.info("Curr Metrics size {}", currMetrics.size());
-    LOG.info("Next Metrics size {}", nextMetrics.size());
-
-    LOG.debug("Start serializing and writing to file.");
-    writeAndRotate(currMetrics, timeBucket, currentTimeMillis);
-    if (!nextMetrics.isEmpty()) {
-      // The next bucket metrics don't need to be considered for
-      // rotation just yet. So, we just write them to the
-      // <nextTimeBucket>.tmp
-      eventLogFileHandler.writeTmpFile(nextMetrics, nextTimeBucket);
-    }
-    LOG.debug("Writing to disk complete.");
-  }
-
-  private void writeAndRotate(final List<Event> currMetrics,
-      long currTimeBucket,
-      long currentTime) {
-    // Going by the continuing example, we will rotate the 5.tmp file to
-    // 5, which contains the metrics with epoch 5-10, whenever the purger
-    // runs after the 15th second.
-    if (lastTimeBucket != 0 && lastTimeBucket != currTimeBucket) {
-      eventLogFileHandler.renameFromTmp(lastTimeBucket);
-    }
-    // This appends the data to a file named <currTimeBucket>.tmp
-    eventLogFileHandler.writeTmpFile(currMetrics, currTimeBucket);
-    lastTimeBucket = currTimeBucket;
-  }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/NodeStatsMetricsCollectorTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/NodeStatsMetricsCollectorTests.java
@@ -35,7 +35,7 @@ public class NodeStatsMetricsCollectorTests extends CustomMetricsLocationTestBas
         
         MetricsConfiguration.CONFIG_MAP.put(NodeStatsMetricsCollector.class, MetricsConfiguration.cdefault);
 
-        NodeStatsMetricsCollector nodeStatsMetricsCollector = new NodeStatsMetricsCollector();
+        NodeStatsMetricsCollector nodeStatsMetricsCollector = new NodeStatsMetricsCollector(null);
         nodeStatsMetricsCollector.saveMetricValues("89123.23", startTimeInMills, "NodesStatsIndex", "55");
 
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/http_action/config/PerformanceAnalyzerResourceProviderTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/http_action/config/PerformanceAnalyzerResourceProviderTest.java
@@ -1,0 +1,150 @@
+/*
+ * Copyright <2019> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.http_action.config;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSettings;
+import org.elasticsearch.common.bytes.BytesReference;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.rest.RestController;
+import org.elasticsearch.rest.RestRequest;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.api.mockito.PowerMockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.core.classloader.annotations.SuppressStaticInitializationFor;
+import org.powermock.modules.junit4.PowerMockRunner;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.HashMap;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+
+@RunWith(PowerMockRunner.class)
+@PrepareForTest({PluginSettings.class})
+@SuppressStaticInitializationFor({"PluginSettings"})
+public class PerformanceAnalyzerResourceProviderTest {
+  @Mock
+  RestController mockRestController;
+  PerformanceAnalyzerResourceProvider performanceAnalyzerRp;
+
+  @Before
+  public void setup() {
+    initMocks(this);
+    initPerformanceAnalyzerResourceProvider(false);
+  }
+
+  private void initPerformanceAnalyzerResourceProvider(boolean isHttpsEnabled) {
+    PluginSettings config = Mockito.mock(PluginSettings.class);
+    Mockito.when(config.getHttpsEnabled()).thenReturn(isHttpsEnabled);
+
+    PowerMockito.mockStatic(PluginSettings.class);
+    PowerMockito.when(PluginSettings.instance()).thenReturn(config);
+
+    performanceAnalyzerRp = new PerformanceAnalyzerResourceProvider(Settings.EMPTY, mockRestController);
+    performanceAnalyzerRp.setPortNumber("9650");
+  }
+
+  private RestRequest generateRestRequest(String requestUri, String redirectEndpoint) {
+    RestRequest request = new RestRequest(null, new HashMap<>(), requestUri, Collections.emptyMap(), null, null) {
+      @Override
+      public Method method() {
+        return Method.GET;
+      }
+
+      @Override
+      public String uri() {
+        return requestUri;
+      }
+
+      @Override
+      public boolean hasContent() {
+        return false;
+      }
+
+      @Override
+      public BytesReference content() {
+        return null;
+      }
+    };
+    request.params().put("redirectEndpoint", redirectEndpoint);
+    return request;
+  }
+
+
+  private void assertAgentUriWithMetricsRedirection(final String protocolScheme) throws IOException {
+    initPerformanceAnalyzerResourceProvider(protocolScheme.equals("https://"));
+
+    String requestURI = protocolScheme + "localhost:9200/_opendistro/_performanceanalyzer/_agent/metrics" +
+            "?metrics=Latency,CPU_Utilization&agg=avg,max&dim=ShardID&nodes=all";
+    String expectedResponseURI = protocolScheme + "localhost:9650/_opendistro/_performanceanalyzer/metrics" +
+            "?metrics=Latency,CPU_Utilization&agg=avg,max&dim=ShardID&nodes=all";
+
+    RestRequest restRequest = generateRestRequest(requestURI, "metrics");
+    URL actualResponseURI = performanceAnalyzerRp.getAgentUri(restRequest);
+    assertEquals(new URL(expectedResponseURI), actualResponseURI);
+  }
+
+
+  private void assertAgentUriWithRcaRedirection(final String protocolScheme) throws IOException {
+    initPerformanceAnalyzerResourceProvider(protocolScheme.equals("https://"));
+
+    String requestUri = protocolScheme + "localhost:9200/_opendistro/_performanceanalyzer/_agent/rca" +
+            "?rca=highShardCPU&startTime=2019-10-11";
+    String expectedResponseUri = protocolScheme + "localhost:9650/_opendistro/_performanceanalyzer/rca" +
+            "?rca=highShardCPU&startTime=2019-10-11";
+
+    RestRequest restRequest = generateRestRequest(requestUri, "rca");
+    URL actualResponseURI = performanceAnalyzerRp.getAgentUri(restRequest);
+    assertEquals(new URL(expectedResponseUri), actualResponseURI);
+  }
+
+
+  @Test
+  public void testGetAgentUri_WithHttp_WithMetricRedirection() throws Exception {
+    assertAgentUriWithMetricsRedirection("http://");
+  }
+
+  @Test
+  public void testGetAgentUri_WithHttps_WithMetricRedirection() throws Exception {
+    assertAgentUriWithRcaRedirection("https://");
+  }
+
+  @Test
+  public void testGetAgentUri_WithHttp_WithRcaRedirection() throws Exception {
+    assertAgentUriWithRcaRedirection("http://");
+  }
+
+  @Test
+  public void testGetAgentUri_WithHttps_WithRcaRedirection() throws Exception {
+    assertAgentUriWithRcaRedirection("https://");
+  }
+
+  @Test
+  public void testGetAgentUri_WithHttp_WithUnsupportedRedirection() throws Exception {
+    String requestUri = "http://localhost:9200/_opendistro/_performanceanalyzer/_agent/invalid";
+    RestRequest request = generateRestRequest(requestUri, "invalid");
+    URL finalURI = performanceAnalyzerRp.getAgentUri(request);
+    assertNull(finalURI);
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/AbstractReaderTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/AbstractReaderTests.java
@@ -37,6 +37,8 @@ import java.lang.reflect.Modifier;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.NodeRole;
 import org.jooq.Condition;
 import org.jooq.impl.DSL;
 import org.junit.Ignore;
@@ -123,7 +125,7 @@ public class AbstractReaderTests extends AbstractTests {
             long indexWriterMemory, long versionMapMemory,
             long bitsetMemory, FailureCondition condition) {
         // dummyCollector is only used to create the json string
-        NodeStatsMetricsCollector dummyCollector = new NodeStatsMetricsCollector();
+        NodeStatsMetricsCollector dummyCollector = new NodeStatsMetricsCollector(null);
         String str = (dummyCollector.new NodeStatsMetricsStatus(
                 indexingThrottleTime,
                  queryCacheHitCount,


### PR DESCRIPTION
Verified that Performance Analyzer is coming up node and responding.

------------------------------------------------------------------------
[root@da675680feb8 tmp]#  curl localhost:9600/_opendistro/_performanceanalyzer/metrics?metrics=CPU_Utilization\&agg=avg | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   157  100   157    0     0  10072      0 --:--:-- --:--:-- --:--:-- 10466
{
    "cKK5UuffRPie7kOLr7HT9A": {
        "data": {
            "fields": [
                {
                    "name": "CPU_Utilization",
                    "type": "DOUBLE"
                }
            ],
            "records": [
                [
                    0.0015881554343092808
                ]
            ]
        },
        "timestamp": 1578529525000
    }
}



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
