### PR TITLE
Add isMasterNode to NodeDetailsStatus

### DIFF
--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/AbstractReaderTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/AbstractReaderTests.java
@@ -179,7 +179,7 @@ public class AbstractReaderTests extends AbstractTests {
     protected String createNodeDetailsMetrics(String id, String ipAddress) {
         StringBuffer value = new StringBuffer();
 
-        value.append(new NodeDetailsStatus(id, ipAddress, NodeRole.UNKNOWN.toString())
+        value.append(new NodeDetailsStatus(id, ipAddress, NodeRole.UNKNOWN.toString(), false)
                 .serialize());
 
         return value.toString();


### PR DESCRIPTION
Add isMasterNode to NodeDetailsStatus. This is a fix required to reduce number of calls made to _cat/master api in rca framework