### PR TITLE
Adding Writer side changes for Mute API

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,25 @@ Then you provide parameters for metrics, aggregations, dimensions, and nodes (op
 ### SAMPLE REQUEST
 GET `_opendistro/_performanceanalyzer/metrics?metrics=Latency,CPU_Utilization&agg=avg,max&dim=ShardID&nodes=all`
 
+## MUTE RCA API
+
+### GET API
+Fetches the list of currently muted RCAs for the cluster
+GET `<endpoint>/_opendistro/_performanceanalyzer/mute_rca/cluster/config`
+
+#### SAMPLE REQUEST
+GET `<endpoint>/_opendistro/_performanceanalyzer/mute_rca/cluster/config`
+
+### POST API
+Mutes the list of RCAs(nodes) within the framework.
+
+POST `<endpoint>/_opendistro/_performanceanalyzer/mute_rca/cluster/config` -H 'Content-Type: application/json' -d '{"muted_rcas": "rca1"}'
+
+* rca1 : valid node within the analysis graph
+
+#### SAMPLE REQUEST
+POST `<endpoint>/_opendistro/_performanceanalyzer/mute_rca/cluster/config` -H 'Content-Type: application/json' -d '{"muted_rcas": "HotNodeRca, HighHeapUsageClusterRca"}'
+
 
 ## Documentation
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerPlugin.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerPlugin.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.setting.handler.MutedRcasSettingHandler;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.setting.handler.NodeStatsSettingHandler;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.http_action.config.PerformanceAnalyzerResourceProvider;
 import java.io.File;
@@ -103,6 +104,7 @@ public final class PerformanceAnalyzerPlugin extends Plugin implements ActionPlu
     private static SecurityManager sm = null;
     private final PerformanceAnalyzerClusterSettingHandler perfAnalyzerClusterSettingHandler;
     private final NodeStatsSettingHandler nodeStatsSettingHandler;
+    private final MutedRcasSettingHandler mutedRcasSettingHandler;
     private final PerformanceAnalyzerController performanceAnalyzerController;
     private final ClusterSettingsManager clusterSettingsManager;
 
@@ -172,7 +174,8 @@ public final class PerformanceAnalyzerPlugin extends Plugin implements ActionPlu
 
         clusterSettingsManager = new ClusterSettingsManager(
                 Arrays.asList(PerformanceAnalyzerClusterSettings.COMPOSITE_PA_SETTING,
-                              PerformanceAnalyzerClusterSettings.PA_NODE_STATS_SETTING));
+                              PerformanceAnalyzerClusterSettings.PA_NODE_STATS_SETTING),
+                Arrays.asList(PerformanceAnalyzerClusterSettings.MUTED_RCA_SETTING));
 
         perfAnalyzerClusterSettingHandler = new PerformanceAnalyzerClusterSettingHandler(
                 performanceAnalyzerController,
@@ -185,6 +188,10 @@ public final class PerformanceAnalyzerPlugin extends Plugin implements ActionPlu
                 clusterSettingsManager);
         clusterSettingsManager.addSubscriberForSetting(PerformanceAnalyzerClusterSettings.PA_NODE_STATS_SETTING,
                 nodeStatsSettingHandler);
+
+        mutedRcasSettingHandler = new MutedRcasSettingHandler(performanceAnalyzerController, clusterSettingsManager);
+        clusterSettingsManager.addSubscriberForStringTypeSetting(PerformanceAnalyzerClusterSettings.MUTED_RCA_SETTING,
+                mutedRcasSettingHandler);
 
         EventLog eventLog = new EventLog();
         EventLogFileHandler eventLogFileHandler = new EventLogFileHandler(eventLog, PluginSettings.instance().getMetricsLocation());
@@ -234,7 +241,7 @@ public final class PerformanceAnalyzerPlugin extends Plugin implements ActionPlu
         PerformanceAnalyzerConfigAction.setInstance(performanceanalyzerConfigAction);
         PerformanceAnalyzerResourceProvider performanceAnalyzerRp = new PerformanceAnalyzerResourceProvider(settings, restController);
         PerformanceAnalyzerClusterConfigAction paClusterConfigAction = new PerformanceAnalyzerClusterConfigAction(settings,
-                restController, perfAnalyzerClusterSettingHandler, nodeStatsSettingHandler);
+                restController, perfAnalyzerClusterSettingHandler, nodeStatsSettingHandler, mutedRcasSettingHandler);
         return Arrays.asList(performanceanalyzerConfigAction, paClusterConfigAction, performanceAnalyzerRp);
     }
 
@@ -273,8 +280,8 @@ public final class PerformanceAnalyzerPlugin extends Plugin implements ActionPlu
     @Override
     public List<Setting<?>> getSettings() {
         return Arrays.asList(PerformanceAnalyzerClusterSettings.COMPOSITE_PA_SETTING,
-                             PerformanceAnalyzerClusterSettings.PA_NODE_STATS_SETTING);
+                             PerformanceAnalyzerClusterSettings.PA_NODE_STATS_SETTING,
+                             PerformanceAnalyzerClusterSettings.MUTED_RCA_SETTING);
     }
 
 }
-

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/setting/ClusterSettingsManager.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/setting/ClusterSettingsManager.java
@@ -27,18 +27,21 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.ESResources;
 public class ClusterSettingsManager implements ClusterStateListener {
     private static final Logger LOG = LogManager.getLogger(ClusterSettingsManager.class);
     private Map<Setting<Integer>, List<ClusterSettingListener<Integer>>> listenerMap = new HashMap<>();
+    private Map<Setting<String>, List<ClusterSettingListener<String>>> stringTypeSettingslistenerMap = new HashMap<>();
     private final List<Setting<Integer>> managedSettings = new ArrayList<>();
+    private final List<Setting<String>> managedStringTypeSettings = new ArrayList<>();
     private final ClusterSettingsResponseHandler clusterSettingsResponseHandler;
 
     private boolean initialized = false;
 
-    public ClusterSettingsManager(List<Setting<Integer>> initialSettings) {
+    public ClusterSettingsManager(List<Setting<Integer>> initialSettings, List<Setting<String>> initialStringTypeSetting) {
         managedSettings.addAll(initialSettings);
+        managedStringTypeSettings.addAll(initialStringTypeSetting);
         this.clusterSettingsResponseHandler = new ClusterSettingsResponseHandler();
     }
 
     /**
-     * Adds a listener that will be called when the requested setting's value changes.
+     * Adds a listener that will be called when the requested Int type setting's value changes.
      *
      * @param setting  The setting that needs to be listened to.
      * @param listener The listener object that will be called when the setting changes.
@@ -52,6 +55,24 @@ public class ClusterSettingsManager implements ClusterStateListener {
             }
         } else {
             listenerMap.put(setting, Collections.singletonList(listener));
+        }
+    }
+
+    /**
+     * Adds a listener that will be called when the requested String type setting's value changes.
+     *
+     * @param setting  The setting that needs to be listened to.
+     * @param listener The listener object that will be called when the setting changes.
+     */
+    public void addSubscriberForStringTypeSetting(Setting<String> setting, ClusterSettingListener<String> listener) {
+        if (stringTypeSettingslistenerMap.containsKey(setting)) {
+            final List<ClusterSettingListener<String>> currentListeners = stringTypeSettingslistenerMap.get(setting);
+            if (!currentListeners.contains(listener)) {
+                currentListeners.add(listener);
+                stringTypeSettingslistenerMap.put(setting, currentListeners);
+            }
+        } else {
+            stringTypeSettingslistenerMap.put(setting, Collections.singletonList(listener));
         }
     }
 
@@ -76,7 +97,7 @@ public class ClusterSettingsManager implements ClusterStateListener {
     }
 
     /**
-     * Updates the requested setting with the requested value across the cluster.
+     * Updates the requested Int Type setting with the requested value across the cluster.
      *
      * @param setting  The setting that needs to be updated.
      * @param newValue The new value for the setting.
@@ -90,10 +111,31 @@ public class ClusterSettingsManager implements ClusterStateListener {
     }
 
     /**
+     * Updates the requested String type setting with the requested value across the cluster.
+     *
+     * @param setting  The setting that needs to be updated.
+     * @param newValue The new value for the setting.
+     */
+    public void updateSetting(final Setting<String> setting, final String newValue) {
+        final ClusterUpdateSettingsRequest request = new ClusterUpdateSettingsRequest();
+        request.persistentSettings(Settings.builder()
+                .put(setting.getKey(), newValue)
+                .build());
+        ESResources.INSTANCE.getClient().admin().cluster().updateSettings(request);
+    }
+
+    /**
      * Registers a setting update listener for all the settings managed by this instance.
      */
     private void registerSettingUpdateListener() {
         for (Setting<Integer> setting : managedSettings) {
+            ESResources.INSTANCE.getClusterService()
+                                .getClusterSettings()
+                                .addSettingsUpdateConsumer(setting, updatedVal -> callListeners(setting, updatedVal));
+        }
+
+        // Currently, the managedStringTypeSettings consist of only Muted RCAs Setting
+        for (Setting<String> setting : managedStringTypeSettings) {
             ESResources.INSTANCE.getClusterService()
                                 .getClusterSettings()
                                 .addSettingsUpdateConsumer(setting, updatedVal -> callListeners(setting, updatedVal));
@@ -148,7 +190,7 @@ public class ClusterSettingsManager implements ClusterStateListener {
      */
     @Override
     public void clusterChanged(final ClusterChangedEvent event) {
-        // Check if cluster state is set, if set, remove the listener and try to read cluster settings.
+        // Check if cluster state is set; if set, remove the listener and try to read cluster settings.
         final ClusterState state = event.state();
 
         if (state != null) {
@@ -159,7 +201,7 @@ public class ClusterSettingsManager implements ClusterStateListener {
     }
 
     /**
-     * Calls all the listeners for the specified setting with the requested value.
+     * Calls all the listeners for the specified Int type setting with the requested value.
      *
      * @param setting      The setting whose listeners need to be notified.
      * @param settingValue The new value for the setting.
@@ -174,6 +216,21 @@ public class ClusterSettingsManager implements ClusterStateListener {
     }
 
     /**
+     * Calls all the listeners for the specified String type setting with the requested value.
+     *
+     * @param setting      The setting whose listeners need to be notified.
+     * @param settingValue The new value for the setting.
+     */
+    private void callListeners(final Setting<String> setting, String settingValue) {
+        final List<ClusterSettingListener<String>> listeners = stringTypeSettingslistenerMap.get(setting);
+        if (listeners != null) {
+            for (ClusterSettingListener<String> listener : listeners) {
+                listener.onSettingUpdate(settingValue);
+            }
+        }
+    }
+
+    /**
      * Class that handles response to GET /_cluster/settings
      */
     private class ClusterSettingsResponseHandler implements ActionListener<ClusterStateResponse> {
@@ -181,7 +238,7 @@ public class ClusterSettingsManager implements ClusterStateListener {
          * Handle action response. This response may constitute a failure or a
          * success but it is up to the listener to make that decision.
          *
-         * @param clusterStateResponse
+         * @param clusterStateResponse  ClusterStateResponse object
          */
         @Override
         public void onResponse(final ClusterStateResponse clusterStateResponse) {
@@ -195,12 +252,19 @@ public class ClusterSettingsManager implements ClusterStateListener {
                     callListeners(setting, settingValue);
                 }
             }
+
+            for (final Setting<String> setting : managedStringTypeSettings) {
+                String settingValue = clusterSettings.get(setting.getKey(), null);
+                if (settingValue != null) {
+                    callListeners(setting, settingValue);
+                }
+            }
         }
 
         /**
          * A failure caused by an exception at some phase of the task.
          *
-         * @param e
+         * @param e Exception
          */
         @Override
         public void onFailure(final Exception e) {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/setting/PerformanceAnalyzerClusterSettings.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/setting/PerformanceAnalyzerClusterSettings.java
@@ -33,4 +33,15 @@ public final class PerformanceAnalyzerClusterSettings {
             Setting.Property.NodeScope,
             Setting.Property.Dynamic
     );
+
+    /**
+     * Muted RCAs
+     * Represents muted RCAs as a comma separated string
+     */
+    public static final Setting<String> MUTED_RCA_SETTING = Setting.simpleString(
+            "cluster.metadata.perf_analyzer.muted_rcas_setting",
+            "",
+            Setting.Property.NodeScope,
+            Setting.Property.Dynamic
+    );
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/setting/handler/MutedRcasSettingHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/setting/handler/MutedRcasSettingHandler.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright <2019> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.config.setting.handler;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PerformanceAnalyzerController;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.setting.ClusterSettingListener;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.setting.ClusterSettingsManager;
+
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.config.setting.PerformanceAnalyzerClusterSettings.MUTED_RCA_SETTING;
+
+public class MutedRcasSettingHandler implements ClusterSettingListener<String> {
+    private final PerformanceAnalyzerController controller;
+    private final ClusterSettingsManager clusterSettingsManager;
+
+    private String currentMutedRcaSettingValue = "";
+
+    public MutedRcasSettingHandler(final PerformanceAnalyzerController controller,
+                                   final ClusterSettingsManager clusterSettingsManager) {
+        this.controller = controller;
+        this.clusterSettingsManager = clusterSettingsManager;
+    }
+
+
+    /**
+     * Updates the Muted RCA setting across the cluster.
+     *
+     * @param value The desired num of shards value for node stats.
+     */
+    public void updateMutedRcasSetting(final String value) {
+        clusterSettingsManager.updateSetting(MUTED_RCA_SETTING, value);
+    }
+
+    /**
+     * Handler that gets called when there is a new value for the setting that this listener
+     * is listening to.
+     *
+     * @param newSettingValue The value of the new setting.
+     */
+    @Override
+    public void onSettingUpdate(final String newSettingValue) {
+        if (newSettingValue != null) {
+            currentMutedRcaSettingValue = newSettingValue;
+            controller.updateMutedRcasState(getMutedRcasSetting());
+        }
+    }
+
+    /**
+     * Gets the current(last seen) cluster setting value.
+     * @return String value for setting.
+     */
+    public String getMutedRcasSetting() {
+        return currentMutedRcaSettingValue;
+    }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/http_action/config/PerformanceAnalyzerConfigAction.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/http_action/config/PerformanceAnalyzerConfigAction.java
@@ -38,6 +38,7 @@ public class PerformanceAnalyzerConfigAction extends BaseRestHandler {
     private static final Logger LOG = LogManager.getLogger(PerformanceAnalyzerConfigAction.class);
     private static final String ENABLED = "enabled";
     private static final String SHARDS_PER_COLLECTION = "shardsPerCollection";
+    private static final String MUTED_RCAS = "muted_rcas";
     private static final String PA_ENABLED = "performanceAnalyzerEnabled";
     private static final String RCA_ENABLED = "rcaEnabled";
     private static final String PA_LOGGING_ENABLED = "loggingEnabled";
@@ -46,6 +47,7 @@ public class PerformanceAnalyzerConfigAction extends BaseRestHandler {
     private static final String RCA_CONFIG_PATH = "/_opendistro/_performanceanalyzer/rca/config";
     private static final String PA_CONFIG_PATH = "/_opendistro/_performanceanalyzer/config";
     private static final String LOGGING_CONFIG_PATH = "/_opendistro/_performanceanalyzer/logging/config";
+    private static final String MUTE_RCA_CLUSTER_CONFIG_PATH = "/_opendistro/_performanceanalyzer/mute_rca/config";
 
     public static PerformanceAnalyzerConfigAction getInstance() {
         return instance;
@@ -72,6 +74,8 @@ public class PerformanceAnalyzerConfigAction extends BaseRestHandler {
         controller.registerHandler(RestRequest.Method.POST, RCA_CONFIG_PATH, this);
         controller.registerHandler(RestRequest.Method.GET, LOGGING_CONFIG_PATH, this);
         controller.registerHandler(RestRequest.Method.POST, LOGGING_CONFIG_PATH, this);
+        controller.registerHandler(RestRequest.Method.GET, MUTE_RCA_CLUSTER_CONFIG_PATH, this);
+        controller.registerHandler(RestRequest.Method.POST, MUTE_RCA_CLUSTER_CONFIG_PATH, this);
     }
 
     @Override
@@ -114,6 +118,14 @@ public class PerformanceAnalyzerConfigAction extends BaseRestHandler {
                     performanceAnalyzerController.updateNodeStatsShardsPerCollection((Integer)shardPerCollectionValue);
                 }
             }
+
+            // update mute rcas setting if exists
+            if (map.containsKey(MUTED_RCAS)) {
+                Object mutedRcasValue = map.get(MUTED_RCAS);
+                if (mutedRcasValue instanceof String) {
+                    performanceAnalyzerController.updateMutedRcasState((String)mutedRcasValue);
+                }
+            }
         }
 
         return channel -> {
@@ -124,6 +136,7 @@ public class PerformanceAnalyzerConfigAction extends BaseRestHandler {
                 builder.field(RCA_ENABLED, performanceAnalyzerController.isRcaEnabled());
                 builder.field(PA_LOGGING_ENABLED, performanceAnalyzerController.isLoggingEnabled());
                 builder.field(SHARDS_PER_COLLECTION, performanceAnalyzerController.getNodeStatsShardsPerCollection());
+                builder.field(MUTED_RCAS, performanceAnalyzerController.getMutedRcas());
                 builder.endObject();
                 channel.sendResponse(new BytesRestResponse(RestStatus.OK, builder));
             } catch (IOException ioe) {


### PR DESCRIPTION
*Description of changes:*

1. Adding changes for RCA Muting Config API
The API enables us to mute a node(RCA) by writing the param value for "muted-rcas" parameter to rca.conf, rca_idle_master.conf and rca_master.conf

Usage :
```
curl -XPOST localhost:9200/_opendistro/_performanceanalyzer/cluster/config -H 'Content-Type: application/json' -d 
'{"muted_rcas": "HotNodeRca, HighHeapUsageClusterRca"}' 
{"currentPerformanceAnalyzerClusterState":3,"shards_per_collection":0,"muted_rcas":"HotNodeRca"}

curl -XGET localhost:9200/_opendistro/_performanceanalyzer/mute_rca/cluster/config
{"currentPerformanceAnalyzerClusterState":3,"shardsPerCollection":0,"muted_rcas":"HotNodeRca, HighHeapUsageClusterRca"}

cat /apollo/_env/khushbr-swift-dev-2-ES_7_1AMI-ES2-p001-158461428126/opendistro_performance_analyzer/pa_config/rca.conf
{
"analysis-graph-implementor" : "com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.store.DummyGraph",
"rca-store-location" : "s3://sifi-store/rcas/",
"threshold-store-location" : "s3://sifi-store/thresholds/",
"new-rca-check-minutes" : 60,
"new-threshold-check-minutes" : 30,
"network-queue-length" : 200,
"max-flow-units-per-vertex-buffer" : 200,
"tags" : {
"locus" : "data-node"
},
"remote-peers" : [ "ip1", "ip2", "ip3" ],
"datastore" : {
"type" : "sqlite",
"location-dir" : "/tmp",
"filename" : "rca.sqlite",
"storage-file-retention-count" : 5,
"rotation-period-seconds" : 21600
},
"muted-rcas" : "HotNodeRca, HighHeapUsageClusterRca"
}`
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
