### PR TITLE
PA will no longer crash when SecurityManager says no

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/http_action/config/PerformanceAnalyzerResourceProvider.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/http_action/config/PerformanceAnalyzerResourceProvider.java
@@ -41,8 +41,7 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.HttpURLConnection;
 import java.net.URL;
-import java.security.KeyManagementException;
-import java.security.NoSuchAlgorithmException;
+import java.security.AccessControlException;
 import java.security.cert.X509Certificate;
 import java.util.List;
 import java.util.Map;
@@ -89,16 +88,22 @@ public class PerformanceAnalyzerResourceProvider extends BaseRestHandler {
         SSLContext sc = SSLContext.getInstance("SSL");
         sc.init(null, trustAllCerts, new java.security.SecureRandom());
         HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
-      } catch (NoSuchAlgorithmException e) {
-        LOG.error("Error encountered while initializing SSLContext", e);
-      } catch (KeyManagementException e) {
-        LOG.error("Error encountered while initializing SSLContext", e);
+      } catch (AccessControlException e) {
+        LOG.info("SecurityManager forbids setting default SSL Socket Factory...using default settings", e);
+      } catch (Exception e) {
+        LOG.info("Error encountered while initializing SSLContext...using default settings", e);
       }
 
       // Create all-trusting host name verifier
       HostnameVerifier allHostsValid = (hostname, session) -> true;
-      // Install the all-trusting host verifier
-      HttpsURLConnection.setDefaultHostnameVerifier(allHostsValid);
+      // Attempt to install the all-trusting host verifier
+      try {
+        HttpsURLConnection.setDefaultHostnameVerifier(allHostsValid);
+      } catch (AccessControlException e) {
+        LOG.info("SecurityManager forbids setting default SSL Socket Factory...using default settings", e);
+      } catch (Exception e) {
+        LOG.info("Error encountered while initializing SSLContext...using default settings", e);
+      }
     }
   }
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/http_action/config/PerformanceAnalyzerResourceProvider.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/http_action/config/PerformanceAnalyzerResourceProvider.java
@@ -89,9 +89,9 @@ public class PerformanceAnalyzerResourceProvider extends BaseRestHandler {
         sc.init(null, trustAllCerts, new java.security.SecureRandom());
         HttpsURLConnection.setDefaultSSLSocketFactory(sc.getSocketFactory());
       } catch (AccessControlException e) {
-        LOG.info("SecurityManager forbids setting default SSL Socket Factory...using default settings", e);
+        LOG.warn("SecurityManager forbids setting default SSL Socket Factory...using default settings", e);
       } catch (Exception e) {
-        LOG.info("Error encountered while initializing SSLContext...using default settings", e);
+        LOG.warn("Error encountered while initializing SSLContext...using default settings", e);
       }
 
       // Create all-trusting host name verifier
@@ -100,9 +100,9 @@ public class PerformanceAnalyzerResourceProvider extends BaseRestHandler {
       try {
         HttpsURLConnection.setDefaultHostnameVerifier(allHostsValid);
       } catch (AccessControlException e) {
-        LOG.info("SecurityManager forbids setting default SSL Socket Factory...using default settings", e);
+        LOG.warn("SecurityManager forbids setting default hostname verifier...using default settings", e);
       } catch (Exception e) {
-        LOG.info("Error encountered while initializing SSLContext...using default settings", e);
+        LOG.warn("Error encountered while initializing hostname verifier...using default settings", e);
       }
     }
   }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
PA attempts to set the default SSL Socket Factory (which defines rules
for the SSL Sockets it creates) as well as default hostname verification
rules when it is initialized by the Elasticsearch plugin loader.

However, this behavior would result in an AccessControlException when
run alongside the opendistro-security plugin. This commit is a simple
fix which allows these two plugins to work together.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
