### PR TITLE
collect queue capacity on writer

### DIFF
--- a/licenses/performanceanalyzer-rca-1.3.jar.sha1
+++ b/licenses/performanceanalyzer-rca-1.3.jar.sha1
@@ -1,1 +1,1 @@
-7ab11a3251d4bd2b09ddca5a4f01e4ef3dbdc9ed
+4ef70ce3a018f743a7a3a343f76ececd8e91fd18

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ThreadPoolMetricsCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ThreadPoolMetricsCollector.java
@@ -57,11 +57,16 @@ public class ThreadPoolMetricsCollector extends PerformanceAnalyzerMetricsCollec
                     //This is for backward compatibility. core ES may or may not emit latency metric
                     // (depending on whether the patch has been applied or not)
                     // so we need to use reflection to check whether getLatency() method exist in ThreadPoolStats.java.
+                    // call stats.getLatency()
                     Method getLantencyMethod = Stats.class.getMethod("getLatency");
                     double latency = (Double) getLantencyMethod.invoke(stats);
+                    // call stats.getCapacity()
+                    Method getCapacityMethod = Stats.class.getMethod("getCapacity");
+                    int capacity = (Integer) getCapacityMethod.invoke(stats);
                     return new ThreadPoolStatus(stats.getName(),
                         stats.getQueue(), stats.getRejected(),
-                        stats.getThreads(), stats.getActive(), latency);
+                        stats.getThreads(), stats.getActive(),
+                        latency, capacity);
                 } catch (Exception e) {
                     //core ES does not have the latency patch. send the threadpool metrics without adding latency.
                     return new ThreadPoolStatus(stats.getName(),
@@ -93,6 +98,8 @@ public class ThreadPoolMetricsCollector extends PerformanceAnalyzerMetricsCollec
         public final int threadsActive;
         @JsonInclude(Include.NON_NULL)
         public final Double queueLatency;
+        @JsonInclude(Include.NON_NULL)
+        public final Integer queueCapacity;
 
           public ThreadPoolStatus(String type,
             int queueSize,
@@ -105,6 +112,7 @@ public class ThreadPoolMetricsCollector extends PerformanceAnalyzerMetricsCollec
             this.threadsCount = threadsCount;
             this.threadsActive = threadsActive;
             this.queueLatency = null;
+            this.queueCapacity = null;
         }
 
         public ThreadPoolStatus(String type,
@@ -112,13 +120,15 @@ public class ThreadPoolMetricsCollector extends PerformanceAnalyzerMetricsCollec
             long rejected,
             int threadsCount,
             int threadsActive,
-            double queueLatency) {
+            double queueLatency,
+            int queueCapacity) {
             this.type = type;
             this.queueSize = queueSize;
             this.rejected = rejected;
             this.threadsCount = threadsCount;
             this.threadsActive = threadsActive;
             this.queueLatency = queueLatency;
+            this.queueCapacity = queueCapacity;
         }
 
         @JsonProperty(ThreadPoolDimension.Constants.TYPE_VALUE)
@@ -149,6 +159,11 @@ public class ThreadPoolMetricsCollector extends PerformanceAnalyzerMetricsCollec
         @JsonProperty(ThreadPoolValue.Constants.QUEUE_LATENCY_VALUE)
         public Double getQueueLatency() {
             return queueLatency;
+        }
+
+        @JsonProperty(ThreadPoolValue.Constants.QUEUE_CAPACITY_VALUE)
+        public Integer getQueueCapacity() {
+            return queueCapacity;
         }
     }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
collect queue capacity on writer. This is to read the capacity from resizable queue in ES. PA will not emit QueueCapacity metric if the patch is not found in core ES.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
