### PR TITLE
Fixup ITs and binding issues

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -45,9 +45,9 @@ jobs:
       # Set the vm.max_map_count system property to the minimum required to run Elasticsearch
     - name: Set vm.max_map_count
       run: sudo sysctl -w vm.max_map_count=262144
-    - name: Start Build
+    - name: Build PA and run Unit Tests
       working-directory: ./tmp/pa
       run: ./gradlew build
     - name: Run Integration Tests
       working-directory: ./tmp/pa
-      run: ./gradlew integTest
+      run: ./gradlew integTest -Dtests.enableIT -Dtests.useDockerCluster

--- a/build.gradle
+++ b/build.gradle
@@ -178,8 +178,16 @@ import org.ajoberstar.gradle.git.tasks.GitClone
 
 String rcaDir
 
+static def propEnabled(property) {
+    return System.getProperty(property) != null
+}
+
 // The following Gradle tasks are used to create a PA/RCA enabled Elasticsearch cluster
+// Pass the -Dtests.enableIT property to Gradle to run ITs
 task cloneGitRepo(type: GitClone) {
+    onlyIf = {
+        propEnabled("tests.enableIT")
+    }
     rcaDir = Paths.get(getProject().getBuildDir().toString(), "performance-analyzer-rca").toString()
     def destination = file(rcaDir)
     uri = "https://github.com/opendistro-for-elasticsearch/performance-analyzer-rca.git"
@@ -188,19 +196,31 @@ task cloneGitRepo(type: GitClone) {
     enabled = !destination.exists() // to clone only once
 }
 
-task setupEsCluster(type: Exec) {
+task setupEsCluster() {
     dependsOn(cloneGitRepo)
-    workingDir(rcaDir)
-    commandLine './gradlew', 'enableRca'
+    onlyIf = {
+        propEnabled("tests.enableIT")
+    }
     doLast {
+        exec {
+            workingDir(rcaDir)
+            commandLine 'sed', '-i', '""', 's|#webservice-bind-host =|webservice-bind-host = 0.0.0.0|g', 'pa_config/performance-analyzer.properties'
+        }
+        exec {
+            workingDir(rcaDir)
+            commandLine './gradlew', 'enableRca'
+        }
         sleep(5000)
     }
 }
 
 integTestRunner {
+    onlyIf = {
+        propEnabled("tests.enableIT")
+    }
     // add "-Dtests.security.manager=false" to VM options if you want to run integ tests in IntelliJ
     systemProperty 'tests.security.manager', 'false'
-    if (System.getProperty("tests.useDockerCluster").equals("true")) {
+    if (propEnabled("tests.useDockerCluster")) {
         dependsOn(setupEsCluster)
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -8,4 +8,5 @@ systemProp.tests.rest.cluster=localhost:9200
 # The Elasticsearch cluster node communication endpoint
 systemProp.tests.cluster=localhost:9300
 # Whether or not to spin up a new Elasticsearch cluster for integration testing
-systemProp.tests.useDockerCluster=true
+# Comment this out if you don't want a cluster spun up
+systemProp.tests.useDockerCluster=

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/util/WaitFor.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/util/WaitFor.java
@@ -1,0 +1,32 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.util;
+
+import java.util.concurrent.Callable;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+/**
+ * This class allows you to wait at most a specified duration until a condition evaluates to true
+ */
+public class WaitFor {
+    /**
+     * Waits at most the specified time for the given task to evaluate to true
+     * @param task The task which we hope evaluates to true before the time limit
+     * @param maxWait The max amount of time to wait for the task to evaluate for true
+     * @param unit The time unit of the maxWait parameter
+     * @throws Exception If the time limit expires before the task evaluates to true
+     */
+    public static void waitFor(Callable<Boolean> task, long maxWait, TimeUnit unit) throws Exception {
+        long maxWaitMillis = TimeUnit.MILLISECONDS.convert(maxWait, unit);
+        long pollTime = System.currentTimeMillis();
+        long curTime;
+        while (!task.call() && maxWaitMillis >= 0) {
+            curTime = System.currentTimeMillis();
+            maxWaitMillis -= (curTime - pollTime);
+            pollTime = curTime;
+        }
+        if (maxWait < 0) {
+            throw new TimeoutException("WaitFor timed out before task evaluated to true");
+        }
+    }
+}
+


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
This commit makes IT execution much more robust and only executes ITs if
the user passes the -Dtests.enableIT flag to the Gradle environment.

This commit also ensures that we bind to all interfaces when we spin up
a local Docker cluster for testing.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
