### PR TITLE
Calculate rejection increase and emit the delta increase of rejection as metric 

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ThreadPoolMetricsCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ThreadPoolMetricsCollector.java
@@ -24,6 +24,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.Performan
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.annotations.VisibleForTesting;
 import java.lang.reflect.Method;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -169,6 +170,19 @@ public class ThreadPoolMetricsCollector extends PerformanceAnalyzerMetricsCollec
             this.threadsActive = threadsActive;
             this.queueLatency = queueLatency;
             this.queueCapacity = queueCapacity;
+        }
+
+        // default constructor for jackson to de-serialize this class
+        // from json string in unit test
+        @VisibleForTesting
+        public ThreadPoolStatus() {
+            this.type = "testing";
+            this.queueSize = -1;
+            this.rejected = -1;
+            this.threadsCount = -1;
+            this.threadsActive = -1;
+            this.queueLatency = null;
+            this.queueCapacity = null;
         }
 
         @JsonProperty(ThreadPoolDimension.Constants.TYPE_VALUE)

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ThreadPoolMetricsCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ThreadPoolMetricsCollector.java
@@ -58,9 +58,9 @@ public class ThreadPoolMetricsCollector extends PerformanceAnalyzerMetricsCollec
         while (statsIterator.hasNext()) {
             Stats stats = statsIterator.next();
             long rejectionDelta = 0;
-            String name = stats.getName();
-            if (statsRecordMap.containsKey(name)) {
-                ThreadPoolStatsRecord lastRecord = statsRecordMap.get(name);
+            String threadPoolName = stats.getName();
+            if (statsRecordMap.containsKey(threadPoolName)) {
+                ThreadPoolStatsRecord lastRecord = statsRecordMap.get(threadPoolName);
                 // if the timestamp in previous record is greater than 15s (3 * intervals),
                 // then the scheduler might hang or freeze due to long GC etc. We simply drop
                 // previous record here and set rejectionDelta to 0.
@@ -73,7 +73,7 @@ public class ThreadPoolMetricsCollector extends PerformanceAnalyzerMetricsCollec
                     }
                 }
             }
-            statsRecordMap.put(name, new ThreadPoolStatsRecord(startTime, stats.getRejected()));
+            statsRecordMap.put(threadPoolName, new ThreadPoolStatsRecord(startTime, stats.getRejected()));
             final long finalRejectionDelta = rejectionDelta;
             ThreadPoolStatus threadPoolStatus = AccessController.doPrivileged((PrivilegedAction<ThreadPoolStatus>) () -> {
                 try {

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ThreadPoolMetricsCollectorTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ThreadPoolMetricsCollectorTests.java
@@ -27,7 +27,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.threadpool.ThreadPool;
 import org.elasticsearch.threadpool.ThreadPoolStats;
 import org.junit.Before;
@@ -44,13 +43,8 @@ public class ThreadPoolMetricsCollectorTests extends CustomMetricsLocationTestBa
 
     @Before
     public void init() {
-        Settings settings = Settings.builder()
-            .put("node.name", ThreadPoolMetricsCollectorTests.class.getSimpleName())
-            .build();
-        //mockThreadPool = new ThreadPool(settings);
         mockThreadPool = Mockito.mock(ThreadPool.class);
         ESResources.INSTANCE.setThreadPool(mockThreadPool);
-
         System.setProperty("performanceanalyzer.metrics.log.enabled", "False");
         MetricsConfiguration.CONFIG_MAP.put(ThreadPoolMetricsCollector.class, MetricsConfiguration.cdefault);
         threadPoolMetricsCollector = new ThreadPoolMetricsCollector();


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The current rejection count that PA emit is the overall rejection of all time since the cluster starts. We need to calculate rejection increase between each sampling so that we can easily tell whether rejection occurs in each time interval.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
