### PR TITLE
Enable spotbugs, address spotbug warnings

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,22 @@ buildscript {
 plugins {
     id 'java'
     id 'nebula.ospackage' version "8.2.0"
+    id 'com.github.spotbugs' version '4.0.0'
+}
+
+spotbugsMain {
+    excludeFilter = file("checkstyle/findbugs-exclude.xml")
+    effort = 'max'
+    ignoreFailures = false
+
+    reports {
+        xml.enabled = false
+        html.enabled = true
+    }
+}
+
+spotbugsTest {
+    ignoreFailures = true
 }
 
 ext {

--- a/checkstyle/findbugs-exclude.xml
+++ b/checkstyle/findbugs-exclude.xml
@@ -1,0 +1,9 @@
+<FindBugsFilter>
+    <Match>
+        <Bug pattern="DM_DEFAULT_ENCODING" />
+    </Match>
+    <Match>
+        <Class name="com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.ThreadPoolMetricsCollector"/>
+        <Bug pattern="REC_CATCH_EXCEPTION"/>
+    </Match>
+</FindBugsFilter>

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/http_action/whoami/WhoAmIAction.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/http_action/whoami/WhoAmIAction.java
@@ -20,9 +20,9 @@ import org.elasticsearch.common.io.stream.Writeable;
 
 public class WhoAmIAction extends ActionType<WhoAmIResponse> {
 
-    public static final WhoAmIAction INSTANCE = new WhoAmIAction();
     public static final String NAME = "cluster:admin/performanceanalyzer/whoami";
     public static final Writeable.Reader<WhoAmIResponse> responseReader = null;
+    public static final WhoAmIAction INSTANCE = new WhoAmIAction();
 
     private WhoAmIAction() {
         super(NAME, responseReader);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Enable spotbugs. Also address the associated spotbug warnings (see below image):
1: The static initializer was moved to after all static final fields were assigned.
2, 3: This warning was disabled like in the rca repo.
4: The associated code throws both RuntimeException's and ReflectiveOperationException's, and both of them should be handled the same way here. So, this warning should not be raised, so it was disabled.

<img width="1437" alt="Screen Shot 2020-06-24 at 11 35 10 PM" src="https://user-images.githubusercontent.com/43506361/85669703-f6206080-b674-11ea-94df-f283c726382a.png">



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
