### PR TITLE
Agent script now uses a variable path to elasticsearch-cli

### DIFF
--- a/packaging/performance-analyzer-agent-cli
+++ b/packaging/performance-analyzer-agent-cli
@@ -7,5 +7,5 @@ PA_AGENT_JAVA_OPTS="-Dlog4j.configurationFile=$ES_HOME/plugins/opendistro_perfor
 ES_MAIN_CLASS="com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp" \
 ES_ADDITIONAL_CLASSPATH_DIRECTORIES=performance-analyzer-rca/lib \
 ES_JAVA_OPTS=$PA_AGENT_JAVA_OPTS \
- /usr/share/elasticsearch/bin/elasticsearch-cli \
+ $ES_HOME/bin/elasticsearch-cli \
    "$@"


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Agent script now uses a variable path to elasticsearch-cli


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
