### PR TITLE
Spliting Node Collector by Performance Impact on the Cluster

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/NodeStatsMetricsCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/NodeStatsMetricsCollector.java
@@ -217,14 +217,23 @@ public class NodeStatsMetricsCollector extends PerformanceAnalyzerMetricsCollect
     }
 
     public void populateMetricValues(IndicesService indicesService, IndexShard currentIndexShard,
-                                long startTime, boolean allShards) {
-        IndexShardStats currentIndexShardStats = this.indexShardStats(indicesService, currentIndexShard, CommonStatsFlags.ALL);
+                                long startTime, boolean allMetrics) {
+        IndexShardStats currentIndexShardStats;
+        if (allMetrics) {
+            currentIndexShardStats = this.indexShardStats(indicesService, currentIndexShard, new CommonStatsFlags(
+                    CommonStatsFlags.Flag.Store, CommonStatsFlags.Flag.Indexing, CommonStatsFlags.Flag.Merge,
+                    CommonStatsFlags.Flag.Flush, CommonStatsFlags.Flag.Refresh, CommonStatsFlags.Flag.QueryCache,
+                    CommonStatsFlags.Flag.FieldData, CommonStatsFlags.Flag.RequestCache, CommonStatsFlags.Flag.Recovery));
+        } else {
+            currentIndexShardStats = this.indexShardStats(indicesService, currentIndexShard, new CommonStatsFlags(
+                    CommonStatsFlags.Flag.Segments));
+        }
         for (ShardStats shardStats : currentIndexShardStats.getShards()) {
             StringBuilder value = new StringBuilder();
 
             value.append(PerformanceAnalyzerMetrics.getJsonCurrentMilliSeconds());
             //- go through the list of metrics to be collected and emit
-            if (allShards) {
+            if (allMetrics) {
                 value.append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor)
                         .append(new NodeStatsMetricsAllShardsPerCollectionStatus(shardStats).serialize());
             } else {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/NodeStatsMetricsCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/NodeStatsMetricsCollector.java
@@ -262,6 +262,14 @@ public class NodeStatsMetricsCollector extends PerformanceAnalyzerMetricsCollect
         @JsonIgnore
         private ShardStats shardStats;
 
+        private final long indexingThrottleTime;
+        private final long refreshCount;
+        private final long refreshTime;
+        private final long flushCount;
+        private final long flushTime;
+        private final long mergeCount;
+        private final long mergeTime;
+        private final long mergeCurrent;
         private final long indexBufferBytes;
         private final long segmentCount;
         private final long segmentsMemory;
@@ -280,6 +288,14 @@ public class NodeStatsMetricsCollector extends PerformanceAnalyzerMetricsCollect
             super();
             this.shardStats = shardStats;
 
+            this.indexingThrottleTime = calculate(ShardStatsValue.INDEXING_THROTTLE_TIME);
+            this.refreshCount = calculate(ShardStatsValue.REFRESH_EVENT);
+            this.refreshTime = calculate(ShardStatsValue.REFRESH_TIME);
+            this.flushCount = calculate(ShardStatsValue.FLUSH_EVENT);
+            this.flushTime = calculate(ShardStatsValue.FLUSH_TIME);
+            this.mergeCount = calculate(ShardStatsValue.MERGE_EVENT);
+            this.mergeTime = calculate(ShardStatsValue.MERGE_TIME);
+            this.mergeCurrent = calculate(ShardStatsValue.MERGE_CURRENT_EVENT);
             this.indexBufferBytes = calculate(ShardStatsValue.INDEXING_BUFFER);
             this.segmentCount = calculate(ShardStatsValue.SEGMENTS_TOTAL);
             this.segmentsMemory = calculate(ShardStatsValue.SEGMENTS_MEMORY);
@@ -298,14 +314,25 @@ public class NodeStatsMetricsCollector extends PerformanceAnalyzerMetricsCollect
         }
 
         @SuppressWarnings("checkstyle:parameternumber")
-        public NodeStatsMetricsFewShardsPerCollectionStatus(long indexBufferBytes,
-                long segmentCount, long segmentsMemory, long termsMemory,
-                long storedFieldsMemory, long termVectorsMemory,
-                long normsMemory, long pointsMemory, long docValuesMemory,
-                long indexWriterMemory, long versionMapMemory,
-                long bitsetMemory, long shardSizeInBytes) {
+        public NodeStatsMetricsFewShardsPerCollectionStatus(long indexingThrottleTime, long refreshCount, long refreshTime,
+                                                            long flushCount, long flushTime, long mergeCount,
+                                                            long mergeTime, long mergeCurrent, long indexBufferBytes,
+                                                            long segmentCount, long segmentsMemory, long termsMemory,
+                                                            long storedFieldsMemory, long termVectorsMemory,
+                                                            long normsMemory, long pointsMemory, long docValuesMemory,
+                                                            long indexWriterMemory, long versionMapMemory,
+                                                            long bitsetMemory, long shardSizeInBytes) {
             super();
             this.shardStats = null;
+
+            this.indexingThrottleTime = indexingThrottleTime;
+            this.refreshCount = refreshCount;
+            this.refreshTime = refreshTime;
+            this.flushCount = flushCount;
+            this.flushTime = flushTime;
+            this.mergeCount = mergeCount;
+            this.mergeTime = mergeTime;
+            this.mergeCurrent = mergeCurrent;
             this.indexBufferBytes = indexBufferBytes;
             this.segmentCount = segmentCount;
             this.segmentsMemory = segmentsMemory;
@@ -324,6 +351,46 @@ public class NodeStatsMetricsCollector extends PerformanceAnalyzerMetricsCollect
 
         private long calculate(ShardStatsValue nodeMetric) {
             return valueCalculators.get(nodeMetric.toString()).calculateValue(shardStats);
+        }
+
+        @JsonProperty(ShardStatsValue.Constants.INDEXING_THROTTLE_TIME_VALUE)
+        public long getIndexingThrottleTime() {
+            return indexingThrottleTime;
+        }
+
+        @JsonProperty(ShardStatsValue.Constants.REFRESH_COUNT_VALUE)
+        public long getRefreshCount() {
+            return refreshCount;
+        }
+
+        @JsonProperty(ShardStatsValue.Constants.REFRESH_TIME_VALUE)
+        public long getRefreshTime() {
+            return refreshTime;
+        }
+
+        @JsonProperty(ShardStatsValue.Constants.FLUSH_COUNT_VALUE)
+        public long getFlushCount() {
+            return flushCount;
+        }
+
+        @JsonProperty(ShardStatsValue.Constants.FLUSH_TIME_VALUE)
+        public long getFlushTime() {
+            return flushTime;
+        }
+
+        @JsonProperty(ShardStatsValue.Constants.MERGE_COUNT_VALUE)
+        public long getMergeCount() {
+            return mergeCount;
+        }
+
+        @JsonProperty(ShardStatsValue.Constants.MERGE_TIME_VALUE)
+        public long getMergeTime() {
+            return mergeTime;
+        }
+
+        @JsonProperty(ShardStatsValue.Constants.MERGE_CURRENT_VALUE)
+        public long getMergeCurrent() {
+            return mergeCurrent;
         }
 
         @JsonIgnore
@@ -402,7 +469,6 @@ public class NodeStatsMetricsCollector extends PerformanceAnalyzerMetricsCollect
         @JsonIgnore
         private ShardStats shardStats;
 
-        private final long indexingThrottleTime;
         private final long queryCacheHitCount;
         private final long queryCacheMissCount;
         private final long queryCacheInBytes;
@@ -412,20 +478,11 @@ public class NodeStatsMetricsCollector extends PerformanceAnalyzerMetricsCollect
         private final long requestCacheMissCount;
         private final long requestCacheEvictions;
         private final long requestCacheInBytes;
-        private final long refreshCount;
-        private final long refreshTime;
-        private final long flushCount;
-        private final long flushTime;
-        private final long mergeCount;
-        private final long mergeTime;
-        private final long mergeCurrent;
 
         public NodeStatsMetricsAllShardsPerCollectionStatus(ShardStats shardStats) {
             super();
             this.shardStats = shardStats;
 
-            this.indexingThrottleTime = calculate(
-                    ShardStatsValue.INDEXING_THROTTLE_TIME);
             this.queryCacheHitCount = calculate(
                     ShardStatsValue.CACHE_QUERY_HIT);
             this.queryCacheMissCount = calculate(
@@ -443,27 +500,17 @@ public class NodeStatsMetricsCollector extends PerformanceAnalyzerMetricsCollect
                     ShardStatsValue.CACHE_REQUEST_EVICTION);
             this.requestCacheInBytes = calculate(
                     ShardStatsValue.CACHE_REQUEST_SIZE);
-            this.refreshCount = calculate(ShardStatsValue.REFRESH_EVENT);
-            this.refreshTime = calculate(ShardStatsValue.REFRESH_TIME);
-            this.flushCount = calculate(ShardStatsValue.FLUSH_EVENT);
-            this.flushTime = calculate(ShardStatsValue.FLUSH_TIME);
-            this.mergeCount = calculate(ShardStatsValue.MERGE_EVENT);
-            this.mergeTime = calculate(ShardStatsValue.MERGE_TIME);
-            this.mergeCurrent = calculate(ShardStatsValue.MERGE_CURRENT_EVENT);
         }
 
         @SuppressWarnings("checkstyle:parameternumber")
-        public NodeStatsMetricsAllShardsPerCollectionStatus(long indexingThrottleTime,
-                                                            long queryCacheHitCount, long queryCacheMissCount,
+        public NodeStatsMetricsAllShardsPerCollectionStatus(long queryCacheHitCount, long queryCacheMissCount,
                                                             long queryCacheInBytes, long fieldDataEvictions,
                                                             long fieldDataInBytes, long requestCacheHitCount,
                                                             long requestCacheMissCount, long requestCacheEvictions,
-                                                            long requestCacheInBytes, long refreshCount, long refreshTime,
-                                                            long flushCount, long flushTime, long mergeCount,
-                                                            long mergeTime, long mergeCurrent) {
+                                                            long requestCacheInBytes) {
             super();
             this.shardStats = null;
-            this.indexingThrottleTime = indexingThrottleTime;
+
             this.queryCacheHitCount = queryCacheHitCount;
             this.queryCacheMissCount = queryCacheMissCount;
             this.queryCacheInBytes = queryCacheInBytes;
@@ -473,13 +520,6 @@ public class NodeStatsMetricsCollector extends PerformanceAnalyzerMetricsCollect
             this.requestCacheMissCount = requestCacheMissCount;
             this.requestCacheEvictions = requestCacheEvictions;
             this.requestCacheInBytes = requestCacheInBytes;
-            this.refreshCount = refreshCount;
-            this.refreshTime = refreshTime;
-            this.flushCount = flushCount;
-            this.flushTime = flushTime;
-            this.mergeCount = mergeCount;
-            this.mergeTime = mergeTime;
-            this.mergeCurrent = mergeCurrent;
         }
 
 
@@ -490,11 +530,6 @@ public class NodeStatsMetricsCollector extends PerformanceAnalyzerMetricsCollect
         @JsonIgnore
         public ShardStats getShardStats() {
             return shardStats;
-        }
-
-        @JsonProperty(ShardStatsValue.Constants.INDEXING_THROTTLE_TIME_VALUE)
-        public long getIndexingThrottleTime() {
-            return indexingThrottleTime;
         }
 
         @JsonProperty(ShardStatsValue.Constants.QUEY_CACHE_HIT_COUNT_VALUE)
@@ -542,39 +577,5 @@ public class NodeStatsMetricsCollector extends PerformanceAnalyzerMetricsCollect
             return requestCacheInBytes;
         }
 
-        @JsonProperty(ShardStatsValue.Constants.REFRESH_COUNT_VALUE)
-        public long getRefreshCount() {
-            return refreshCount;
-        }
-
-        @JsonProperty(ShardStatsValue.Constants.REFRESH_TIME_VALUE)
-        public long getRefreshTime() {
-            return refreshTime;
-        }
-
-        @JsonProperty(ShardStatsValue.Constants.FLUSH_COUNT_VALUE)
-        public long getFlushCount() {
-            return flushCount;
-        }
-
-        @JsonProperty(ShardStatsValue.Constants.FLUSH_TIME_VALUE)
-        public long getFlushTime() {
-            return flushTime;
-        }
-
-        @JsonProperty(ShardStatsValue.Constants.MERGE_COUNT_VALUE)
-        public long getMergeCount() {
-            return mergeCount;
-        }
-
-        @JsonProperty(ShardStatsValue.Constants.MERGE_TIME_VALUE)
-        public long getMergeTime() {
-            return mergeTime;
-        }
-
-        @JsonProperty(ShardStatsValue.Constants.MERGE_CURRENT_VALUE)
-        public long getMergeCurrent() {
-            return mergeCurrent;
-        }
     }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/JsonKeyTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/JsonKeyTests.java
@@ -26,7 +26,6 @@ import java.util.function.Function;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.CircuitBreakerCollector.CircuitBreakerStatus;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.HeapMetricsCollector.HeapStatus;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MasterServiceMetrics.MasterPendingStatus;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.NodeStatsMetricsCollector.NodeStatsMetricsStatus;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.ThreadPoolMetricsCollector.ThreadPoolStatus;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.CircuitBreakerDimension;
@@ -99,9 +98,6 @@ public class JsonKeyTests {
                 IPDimension.values(), IPValue.values(), getMethodJsonProperty);
         verifyMethodWithJsonKeyNames(ThreadPoolStatus.class,
                 ThreadPoolDimension.values(), ThreadPoolValue.values(),
-                getMethodJsonProperty);
-        verifyMethodWithJsonKeyNames(NodeStatsMetricsStatus.class,
-                new MetricDimension[] {}, ShardStatsValue.values(),
                 getMethodJsonProperty);
         verifyMethodWithJsonKeyNames(MasterPendingStatus.class,
                 new MetricDimension[] {},

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/JsonKeyTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/JsonKeyTests.java
@@ -37,7 +37,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetric
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.IPDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.IPValue;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.MasterPendingValue;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ShardStatsValue;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.TCPDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.TCPValue;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ThreadPoolDimension;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/AbstractReaderTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/AbstractReaderTests.java
@@ -125,24 +125,7 @@ public class AbstractReaderTests extends AbstractTests {
             long bitsetMemory, long shardSizeInBytes, FailureCondition condition) {
         // dummyCollector is only used to create the json string
         NodeStatsMetricsCollector dummyCollector = new NodeStatsMetricsCollector(null);
-        String str = (dummyCollector.new NodeStatsMetricsStatus(
-                indexingThrottleTime,
-                 queryCacheHitCount,
-                 queryCacheMissCount,
-                 queryCacheInBytes,
-                 fieldDataEvictions,
-                 fieldDataInBytes,
-                 requestCacheHitCount,
-                 requestCacheMissCount,
-                 requestCacheEvictions,
-                 requestCacheInBytes,
-                 refreshCount,
-                 refreshTime,
-                 flushCount,
-                 flushTime,
-                 mergeCount,
-                 mergeTime,
-                 mergeCurrent,
+        String str = (dummyCollector.new NodeStatsMetricsFewShardsPerCollectionStatus(
                  indexBufferBytes,
                  segmentCount,
                  segmentsMemory,
@@ -155,6 +138,25 @@ public class AbstractReaderTests extends AbstractTests {
                  indexWriterMemory,
                  versionMapMemory,
                  bitsetMemory, shardSizeInBytes)).serialize();
+
+        str += (dummyCollector.new NodeStatsMetricsAllShardsPerCollectionStatus(
+                indexingThrottleTime,
+                queryCacheHitCount,
+                queryCacheMissCount,
+                queryCacheInBytes,
+                fieldDataEvictions,
+                fieldDataInBytes,
+                requestCacheHitCount,
+                requestCacheMissCount,
+                requestCacheEvictions,
+                requestCacheInBytes,
+                refreshCount,
+                refreshTime,
+                flushCount,
+                flushTime,
+                mergeCount,
+                mergeTime,
+                mergeCurrent)).serialize();
 
         if (condition == FailureCondition.INVALID_JSON_METRIC) {
             str = str.substring(1);

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/AbstractReaderTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader/AbstractReaderTests.java
@@ -126,21 +126,28 @@ public class AbstractReaderTests extends AbstractTests {
         // dummyCollector is only used to create the json string
         NodeStatsMetricsCollector dummyCollector = new NodeStatsMetricsCollector(null);
         String str = (dummyCollector.new NodeStatsMetricsFewShardsPerCollectionStatus(
-                 indexBufferBytes,
-                 segmentCount,
-                 segmentsMemory,
-                 termsMemory,
-                 storedFieldsMemory,
-                 termVectorsMemory,
-                 normsMemory,
-                 pointsMemory,
-                 docValuesMemory,
-                 indexWriterMemory,
-                 versionMapMemory,
-                 bitsetMemory, shardSizeInBytes)).serialize();
+                indexingThrottleTime,
+                refreshCount,
+                refreshTime,
+                flushCount,
+                flushTime,
+                mergeCount,
+                mergeTime,
+                mergeCurrent,
+                indexBufferBytes,
+                segmentCount,
+                segmentsMemory,
+                termsMemory,
+                storedFieldsMemory,
+                termVectorsMemory,
+                normsMemory,
+                pointsMemory,
+                docValuesMemory,
+                indexWriterMemory,
+                versionMapMemory,
+                bitsetMemory, shardSizeInBytes)).serialize();
 
         str += (dummyCollector.new NodeStatsMetricsAllShardsPerCollectionStatus(
-                indexingThrottleTime,
                 queryCacheHitCount,
                 queryCacheMissCount,
                 queryCacheInBytes,
@@ -149,14 +156,7 @@ public class AbstractReaderTests extends AbstractTests {
                 requestCacheHitCount,
                 requestCacheMissCount,
                 requestCacheEvictions,
-                requestCacheInBytes,
-                refreshCount,
-                refreshTime,
-                flushCount,
-                flushTime,
-                mergeCount,
-                mergeTime,
-                mergeCurrent)).serialize();
+                requestCacheInBytes)).serialize();
 
         if (condition == FailureCondition.INVALID_JSON_METRIC) {
             str = str.substring(1);


### PR DESCRIPTION
*Issue #, if available:* 

*Description of changes:* Collecting Node Stat Metrics for all the shards at once creates Performance impacts on the cluster. This PR is aimed at splitting the collector between the metrics which cause performance impact and others. 

*Testing:* In progress, to filter out the exact impact improvement. 
 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
