### PR TITLE
Fixing checkstyle build failure

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/CacheConfigMetricsCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/CacheConfigMetricsCollector.java
@@ -22,7 +22,6 @@ import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.Al
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.ESResources;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.CacheConfigDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.CacheConfigValue;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.CacheType;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsProcessor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;


### PR DESCRIPTION
*Description of changes:* Fixing checkstyle build failure caused by unused import. 
Build Failure : https://github.com/opendistro-for-elasticsearch/performance-analyzer/runs/920086188
```
> Task :checkstyleMain
[ant:checkstyle] [ERROR] /home/runner/work/performance-analyzer/performance-analyzer/tmp/pa/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/CacheConfigMetricsCollector.java:25:8: Unused import - com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.CacheType. [UnusedImports]

```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
