### PR TITLE
Use the correct ctor for NodeDetailsCollector

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerPlugin.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerPlugin.java
@@ -188,7 +188,7 @@ public final class PerformanceAnalyzerPlugin extends Plugin implements ActionPlu
 
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new MetricsPurgeActivity());
 
-        scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new NodeDetailsCollector());
+        scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new NodeDetailsCollector(configOverridesWrapper));
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new
                 NodeStatsAllShardsMetricsCollector(performanceAnalyzerController));
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/NodeDetailsCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/NodeDetailsCollector.java
@@ -68,8 +68,12 @@ public class NodeDetailsCollector extends PerformanceAnalyzerMetricsCollector im
         // know this information in advance unless we add the number of nodes as
         // additional metadata in the file.
         try {
-            String rcaOverrides = ConfigOverridesHelper.serialize(configOverridesWrapper.getCurrentClusterConfigOverrides());
-            value.append(rcaOverrides);
+            if (configOverridesWrapper != null) {
+                String rcaOverrides = ConfigOverridesHelper.serialize(configOverridesWrapper.getCurrentClusterConfigOverrides());
+                value.append(rcaOverrides);
+            } else {
+                LOG.warn("Overrides wrapper is null. Check NodeDetailsCollector instantiation.");
+            }
         } catch (IOException ioe) {
             LOG.error("Unable to serialize rca config overrides.", ioe);
         }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/NodeDetailsCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/NodeDetailsCollector.java
@@ -80,7 +80,11 @@ public class NodeDetailsCollector extends PerformanceAnalyzerMetricsCollector im
         value.append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
         
         // line#3 denotes when the timestamp when the config override happened.
-        value.append(configOverridesWrapper.getLastUpdatedTimestamp());
+        if (configOverridesWrapper != null) {
+            value.append(configOverridesWrapper.getLastUpdatedTimestamp());
+        } else {
+            value.append(0L);
+        }
         value.append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
 
         DiscoveryNodes discoveryNodes = ESResources.INSTANCE.getClusterService().state().nodes();

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/setting/handler/ConfigOverridesClusterSettingHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/setting/handler/ConfigOverridesClusterSettingHandler.java
@@ -57,9 +57,13 @@ public class ConfigOverridesClusterSettingHandler implements ClusterSettingListe
     @Override
     public void onSettingUpdate(String newSettingValue) {
         try {
-            final ConfigOverrides newOverrides = ConfigOverridesHelper.deserialize(newSettingValue);
-            overridesHolder.setCurrentClusterConfigOverrides(newOverrides);
-            overridesHolder.setLastUpdatedTimestamp(System.currentTimeMillis());
+            if (newSettingValue != null && !newSettingValue.isEmpty()) {
+                final ConfigOverrides newOverrides = ConfigOverridesHelper.deserialize(newSettingValue);
+                overridesHolder.setCurrentClusterConfigOverrides(newOverrides);
+                overridesHolder.setLastUpdatedTimestamp(System.currentTimeMillis());
+            } else {
+                LOG.warn("Config override setting update called with empty string. Ignoring.");
+            }
         } catch (IOException e) {
             LOG.error("Unable to apply received cluster setting update: " + newSettingValue, e);
         }
@@ -73,8 +77,7 @@ public class ConfigOverridesClusterSettingHandler implements ClusterSettingListe
      */
     public void updateConfigOverrides(final ConfigOverrides newOverrides) throws IOException {
         String newClusterSettingValue = buildClusterSettingValue(newOverrides);
-        // TODO: @ktkrg - Change to debug
-        LOG.error("Updating cluster setting with new overrides string: {}", newClusterSettingValue);
+        LOG.debug("Updating cluster setting with new overrides string: {}", newClusterSettingValue);
         clusterSettingsManager.updateSetting(setting, newClusterSettingValue);
     }
 


### PR DESCRIPTION
*Issue #, if available:*
Fixes #165 
Fixes #164 

*Description of changes:*
The NodeDetailsCollector instantiation in the plugin was overwritten by change #162 

This change instantiates the node details collector correctly.
This change also gets rid of the confusing stacktrace that gets printed during ES startup.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
