### PR TITLE
Fix invalid cluster state

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/setting/handler/PerformanceAnalyzerClusterSettingHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/setting/handler/PerformanceAnalyzerClusterSettingHandler.java
@@ -165,7 +165,7 @@ public class PerformanceAnalyzerClusterSettingHandler implements ClusterSettingL
         int clusterSetting = currentClusterSetting;
 
         if (shouldEnable) {
-            return checkPerformanceAnalyzerEnabled(currentClusterSetting)
+            return checkBit(currentClusterSetting, PA_ENABLED_BIT_POS)
                 ? setBit(clusterSetting, RCA_ENABLED_BIT_POS) : clusterSetting;
         } else {
             return resetBit(clusterSetting, RCA_ENABLED_BIT_POS);
@@ -183,7 +183,7 @@ public class PerformanceAnalyzerClusterSettingHandler implements ClusterSettingL
         int clusterSetting = currentClusterSetting;
 
         if (shouldEnable) {
-            return checkPerformanceAnalyzerEnabled(currentClusterSetting)
+            return checkBit(currentClusterSetting, PA_ENABLED_BIT_POS)
                 ? setBit(clusterSetting, LOGGING_ENABLED_BIT_POS) : clusterSetting;
         } else {
             return resetBit(clusterSetting, LOGGING_ENABLED_BIT_POS);
@@ -211,14 +211,15 @@ public class PerformanceAnalyzerClusterSettingHandler implements ClusterSettingL
     private int resetBit(int number, int bitPosition) {
         return bitPosition < MAX_ALLOWED_BIT_POS ? (number & ~(1 << bitPosition)) : number;
     }
-
+    
     /**
-    * Checks if the pa is set or not.
-    *
-    * @param number The number which needs to be checked.
-    * @return true if the PA_ENABLED bit is set, false otherwise.
-    */
-    private boolean checkPerformanceAnalyzerEnabled(int number) {
-        return ((number & (1 << PA_ENABLED_BIT_POS)) == ENABLED_VALUE);
+     * Checks if the bit is set or not at the specified position.
+     *
+     * @param clusterSettingValue The number which needs to be checked.
+     * @param bitPosition The position of the bit in the clusterSettingValue
+     * @return true if the bit is set, false otherwise.
+     */
+    private boolean checkBit(int clusterSettingValue, int bitPosition) {
+        return ((bitPosition < MAX_ALLOWED_BIT_POS) & (clusterSettingValue & (1 << bitPosition)) == ENABLED_VALUE);
     }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/setting/handler/PerformanceAnalyzerClusterSettingHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/setting/handler/PerformanceAnalyzerClusterSettingHandler.java
@@ -165,7 +165,8 @@ public class PerformanceAnalyzerClusterSettingHandler implements ClusterSettingL
         int clusterSetting = currentClusterSetting;
 
         if (shouldEnable) {
-            return controller.isPerformanceAnalyzerEnabled() ? setBit(clusterSetting, RCA_ENABLED_BIT_POS) : clusterSetting;
+            return checkPerformanceAnalyzerEnabled(currentClusterSetting)
+                ? setBit(clusterSetting, RCA_ENABLED_BIT_POS) : clusterSetting;
         } else {
             return resetBit(clusterSetting, RCA_ENABLED_BIT_POS);
         }
@@ -182,7 +183,8 @@ public class PerformanceAnalyzerClusterSettingHandler implements ClusterSettingL
         int clusterSetting = currentClusterSetting;
 
         if (shouldEnable) {
-            return controller.isPerformanceAnalyzerEnabled() ? setBit(clusterSetting, LOGGING_ENABLED_BIT_POS) : clusterSetting;
+            return checkPerformanceAnalyzerEnabled(currentClusterSetting)
+                ? setBit(clusterSetting, LOGGING_ENABLED_BIT_POS) : clusterSetting;
         } else {
             return resetBit(clusterSetting, LOGGING_ENABLED_BIT_POS);
         }
@@ -208,5 +210,15 @@ public class PerformanceAnalyzerClusterSettingHandler implements ClusterSettingL
      */
     private int resetBit(int number, int bitPosition) {
         return bitPosition < MAX_ALLOWED_BIT_POS ? (number & ~(1 << bitPosition)) : number;
+    }
+
+    /**
+    * Checks if the pa is set or not.
+    *
+    * @param number The number which needs to be checked.
+    * @return true if the PA_ENABLED bit is set, false otherwise.
+    */
+    private boolean checkPerformanceAnalyzerEnabled(int number) {
+        return ((number & (1 << PA_ENABLED_BIT_POS)) == ENABLED_VALUE);
     }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/PerformanceAnalyzerClusterSettingHandlerTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/PerformanceAnalyzerClusterSettingHandlerTest.java
@@ -66,6 +66,17 @@ public class PerformanceAnalyzerClusterSettingHandlerTest {
         assertEquals(0, clusterSettingHandler.getCurrentClusterSettingValue());
     }
 
+    @Test
+    public void updateClusterStateTest() {
+        setControllerValues(ENABLED_STATE, ENABLED_STATE, DISABLED_STATE);
+        clusterSettingHandler =
+                new PerformanceAnalyzerClusterSettingHandler(
+                        mockPerformanceAnalyzerController, mockClusterSettingsManager);
+        assertEquals(3, clusterSettingHandler.getCurrentClusterSettingValue());
+        clusterSettingHandler.onSettingUpdate(0);
+        assertEquals(0, clusterSettingHandler.getCurrentClusterSettingValue());
+    }
+
     private void setControllerValues(final Boolean paEnabled, final Boolean rcaEnabled, final Boolean loggingEnabled) {
         when(mockPerformanceAnalyzerController.isPerformanceAnalyzerEnabled()).thenReturn(paEnabled);
         when(mockPerformanceAnalyzerController.isRcaEnabled()).thenReturn(rcaEnabled);


### PR DESCRIPTION
*Fixes #, if available:*
https://github.com/opendistro-for-elasticsearch/performance-analyzer/issues/152

*Description of changes:*
Fix Cluster settings entering an invalid state. 
Cluster setting references to node values when updating. This causes cluster state to move to an invalid state

Output:

Case1:
Enable PA on a node
Enable RCA/Logging on a node
Enable RCA/Logging on the cluster
```
{
    "currentPerformanceAnalyzerClusterState": 0,
    "shardsPerCollection": 0
}

{
    "performanceAnalyzerEnabled": true,
    "rcaEnabled": true,
    "loggingEnabled": false,
    "shardsPerCollection": 0
}
```

Case2:
Enable PA on a node
Enable RCA/Logging on the cluster
```
{
    "currentPerformanceAnalyzerClusterState": 2,
    "shardsPerCollection": 0
}

{
    "performanceAnalyzerEnabled": true,
    "rcaEnabled":false,
    "loggingEnabled": false,
    "shardsPerCollection": 0
}
```

*Description of changes:*
unit test and tested on AES.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
