### PR TITLE
Update the Cache Hit, Miss and Eviction metrics to be emitted as delta increase/decrease

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/NodeStatsAllShardsMetricsCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/NodeStatsAllShardsMetricsCollector.java
@@ -50,8 +50,8 @@ public class NodeStatsAllShardsMetricsCollector extends PerformanceAnalyzerMetri
     private static final int KEYS_PATH_LENGTH = 2;
     private static final Logger LOG = LogManager.getLogger(NodeStatsAllShardsMetricsCollector.class);
     private HashMap<ShardId, IndexShard> currentShards;
-    HashMap<ShardId, ShardStats> currentPerShardStats;
-    HashMap<ShardId, ShardStats> prevPerShardStats;
+    private HashMap<ShardId, ShardStats> currentPerShardStats;
+    private HashMap<ShardId, ShardStats> prevPerShardStats;
     private final PerformanceAnalyzerController controller;
 
 
@@ -64,8 +64,8 @@ public class NodeStatsAllShardsMetricsCollector extends PerformanceAnalyzerMetri
     }
 
     private void populateCurrentShards() {
-        if (currentShards.size() != 0) {
-            prevPerShardStats = currentPerShardStats;
+        if (!currentShards.isEmpty()) {
+            prevPerShardStats.putAll(currentPerShardStats);
             currentPerShardStats.clear();
         }
         currentShards.clear();
@@ -120,7 +120,7 @@ public class NodeStatsAllShardsMetricsCollector extends PerformanceAnalyzerMetri
                     continue;
                 }
                 ShardStats prevShardStats = prevPerShardStats.get(shardId);
-                if (prevShardStats != null) {
+                if (prevShardStats == null) {
                     // Populate value for shards which are new and were not present in the previous run.
                     populateMetricValue(currentShardStats, startTime, shardId.getIndexName(), shardId.id());
                     continue;
@@ -179,7 +179,7 @@ public class NodeStatsAllShardsMetricsCollector extends PerformanceAnalyzerMetri
         NodeStatsMetricsAllShardsPerCollectionStatus nodeStatsMetrics = new NodeStatsMetricsAllShardsPerCollectionStatus(
                 Math.max((currValue.queryCacheHitCount - prevValue.queryCacheHitCount), 0),
                 Math.max((currValue.queryCacheMissCount - prevValue.queryCacheMissCount), 0),
-                Math.max((currValue.queryCacheInBytes - prevValue.fieldDataInBytes), 0),
+                Math.max((currValue.queryCacheInBytes - prevValue.queryCacheInBytes), 0),
                 Math.max((currValue.fieldDataEvictions - prevValue.fieldDataEvictions), 0),
                 Math.max((currValue.fieldDataInBytes - prevValue.fieldDataInBytes), 0),
                 Math.max((currValue.requestCacheHitCount - prevValue.requestCacheHitCount), 0),

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/NodeStatsAllShardsMetricsCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/NodeStatsAllShardsMetricsCollector.java
@@ -177,15 +177,15 @@ public class NodeStatsAllShardsMetricsCollector extends PerformanceAnalyzerMetri
         StringBuilder value = new StringBuilder();
 
         NodeStatsMetricsAllShardsPerCollectionStatus nodeStatsMetrics = new NodeStatsMetricsAllShardsPerCollectionStatus(
-                (currValue.queryCacheHitCount - prevValue.queryCacheHitCount),
-                (currValue.queryCacheMissCount - prevValue.queryCacheMissCount),
-                (currValue.queryCacheInBytes - prevValue.fieldDataInBytes),
-                (currValue.fieldDataEvictions - prevValue.fieldDataEvictions),
-                (currValue.fieldDataInBytes - prevValue.fieldDataInBytes),
-                (currValue.requestCacheHitCount - prevValue.requestCacheHitCount),
-                (currValue.requestCacheMissCount - prevValue.queryCacheMissCount),
-                (currValue.requestCacheEvictions - prevValue.requestCacheEvictions),
-                (currValue.requestCacheInBytes - prevValue.requestCacheInBytes));
+                Math.max((currValue.queryCacheHitCount - prevValue.queryCacheHitCount), 0),
+                Math.max((currValue.queryCacheMissCount - prevValue.queryCacheMissCount), 0),
+                Math.max((currValue.queryCacheInBytes - prevValue.fieldDataInBytes), 0),
+                Math.max((currValue.fieldDataEvictions - prevValue.fieldDataEvictions), 0),
+                Math.max((currValue.fieldDataInBytes - prevValue.fieldDataInBytes), 0),
+                Math.max((currValue.requestCacheHitCount - prevValue.requestCacheHitCount), 0),
+                Math.max((currValue.requestCacheMissCount - prevValue.requestCacheMissCount), 0),
+                Math.max((currValue.requestCacheEvictions - prevValue.requestCacheEvictions), 0),
+                Math.max((currValue.requestCacheInBytes - prevValue.requestCacheInBytes), 0));
 
         value.append(PerformanceAnalyzerMetrics.getJsonCurrentMilliSeconds())
                 .append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor)

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/NodeStatsAllShardsMetricsCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/NodeStatsAllShardsMetricsCollector.java
@@ -43,6 +43,19 @@ import com.fasterxml.jackson.annotation.JsonProperty;
  * on the performance of the node.
  */
 
+/**
+ * currentShards: Contains the Mapping of the Shard ID to the Shard for the shards currently present on
+ * the cluster in this run of the collector.
+ * currentPerShardStats: Contains the mapping of the Shard Stats and the shards present in this run
+ * of the collector.
+ * prevPerShardStats: Contains the mapping of the Shard Stats and the shards present in the previous
+ * run of the collector.
+ * The diff is calculated between (currentPerShardStats and prevPerShardStats) for each shard in the
+ * currentShards and for shards not present in the prevPerShardStat absolute value of the
+ * currentPerShardStats is updated.
+ */
+
+
 @SuppressWarnings("unchecked")
 public class NodeStatsAllShardsMetricsCollector extends PerformanceAnalyzerMetricsCollector implements MetricsProcessor {
     public static final int SAMPLING_TIME_INTERVAL = MetricsConfiguration.CONFIG_MAP.get(

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/NodeStatsFixedShardsMetricsCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/NodeStatsFixedShardsMetricsCollector.java
@@ -27,6 +27,7 @@ import org.elasticsearch.action.admin.indices.stats.CommonStatsFlags;
 import org.elasticsearch.action.admin.indices.stats.IndexShardStats;
 import org.elasticsearch.action.admin.indices.stats.ShardStats;
 import org.elasticsearch.index.shard.IndexShard;
+import org.elasticsearch.index.shard.ShardId;
 import org.elasticsearch.indices.IndicesService;
 import org.elasticsearch.indices.NodeIndicesStats;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.ESResources;
@@ -51,8 +52,8 @@ public class NodeStatsFixedShardsMetricsCollector extends PerformanceAnalyzerMet
             NodeStatsAllShardsMetricsCollector.class).samplingInterval;
     private static final int KEYS_PATH_LENGTH = 2;
     private static final Logger LOG = LogManager.getLogger(NodeStatsFixedShardsMetricsCollector.class);
-    private HashMap<String, IndexShard> currentShards;
-    private Iterator<HashMap.Entry<String, IndexShard>> currentShardsIter;
+    private HashMap<ShardId, IndexShard> currentShards;
+    private Iterator<HashMap.Entry<ShardId, IndexShard>> currentShardsIter;
     private final PerformanceAnalyzerController controller;
 
     public NodeStatsFixedShardsMetricsCollector(final PerformanceAnalyzerController controller) {
@@ -105,7 +106,7 @@ public class NodeStatsFixedShardsMetricsCollector extends PerformanceAnalyzerMet
     } };
 
     private long getIndexBufferBytes(ShardStats shardStats) {
-        IndexShard shard = currentShards.get(Utils.getUniqueShardIdKey(shardStats.getShardRouting().shardId()));
+        IndexShard shard = currentShards.get(shardStats.getShardRouting().shardId());
 
         if (shard == null) {
             return 0;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/util/Utils.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/util/Utils.java
@@ -85,21 +85,17 @@ public class Utils {
                 });
     }
 
-    public static HashMap<String, IndexShard> getShards() {
-        HashMap<String, IndexShard> shards =  new HashMap<>();
+    public static HashMap<ShardId, IndexShard> getShards() {
+        HashMap<ShardId, IndexShard> shards =  new HashMap<>();
         Iterator<IndexService> indexServices = ESResources.INSTANCE.getIndicesService().iterator();
         while (indexServices.hasNext()) {
             Iterator<IndexShard> indexShards = indexServices.next().iterator();
             while (indexShards.hasNext()) {
                 IndexShard shard = indexShards.next();
-                shards.put(getUniqueShardIdKey(shard.shardId()), shard);
+                shards.put(shard.shardId(), shard);
             }
         }
         return shards;
-    }
-
-    public static String getUniqueShardIdKey(ShardId shardId) {
-        return "[" + shardId.hashCode() + "][" + shardId.getId() + "]";
     }
 
     public static final EnumSet<IndexShardState> CAN_WRITE_INDEX_BUFFER_STATES = EnumSet.of(


### PR DESCRIPTION
*Fixes #, if available:* #170 

*Description of changes:* We need to emit the cache hit, miss and eviction metrics as delta rather than absolute values. ES reports these metrics from beginning of process/post an invalidateAll() event/ post cache clear.

This change calculated the metrics count delta between each sampling to correctly reflect the increase/decrease in the metric count for the evaluation Interval (5seconds for us)

This is done for FieldData, Shard Request and Node Query Cache.

*Testing:* Absolute Value of Metrics as taken from ES:  {"Cache_Query_Hit":0,"Cache_Query_Miss":0,"Cache_Query_Size":0,"Cache_FieldData_Eviction":0,"Cache_FieldData_Size":0,"Cache_Request_Hit":0,"Cache_Request_Miss":1,"Cache_Request_Eviction":0,"Cache_Request_Size":757} {"Cache_Query_Hit":0,"Cache_Query_Miss":0,"Cache_Query_Size":0,"Cache_FieldData_Eviction":0,"Cache_FieldData_Size":0,"Cache_Request_Hit":0,"Cache_Request_Miss":1,"Cache_Request_Eviction":0,"Cache_Request_Size":757}

Values Populated in the Metrics DB for the same time window: 

{"Cache_Query_Hit":0,"Cache_Query_Miss":0,"Cache_Query_Size":0,"Cache_FieldData_Eviction":0,"Cache_FieldData_Size":0,"Cache_Request_Hit":0,"Cache_Request_Miss":0,"Cache_Request_Eviction":0,"Cache_Request_Size":0}

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
