### PR TITLE
Update PerformanceAnalyzerIT to work with opendistro-security

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -247,11 +247,17 @@ task setupEsCluster() {
  * each of these properties.
  *
  * -Dtests.rest.cluster the Elasticsearch REST endpoint that test clients should hit
- * -Dtests.cluster the Elasticsearch transport endpoint that test clients should hit
+ * -Dtests.cluster the Elasticsearch <a href="https://discuss.elastic.co/t/transport-client-vs-rest-client/13936">transport</a>
+ *      endpoint that test clients should hit
  * -Dtests.enableIT a flag to enable integration testing, by default this is false
  * -Dtests.useDockerCluster if true, spin up a local 2 node cluster before executing tests
  *        NOTE: if you specify this, don't specify -Dtests.rest.cluster or -Dtests.cluster
  * -Dtests.pa.port the port number of the PerformanceAnalyzer REST endpoint
+ * -Dtests.https either true or false, if true, then instantiate REST and transport clients using
+ *      the https:// protocol and basic authentication via the -Dtests.user and -Dtests.password properties
+ * -Dtests.user the username of the admin user, this is used in conjunction with -Dtests.https and
+ *      -Dtests.password to authenticate requests in the opendistro-security context
+ * -Dtests.password the password of the admin user specified by -Dtests.user
  */
 integTestRunner {
     onlyIf = {

--- a/build.gradle
+++ b/build.gradle
@@ -201,6 +201,10 @@ static def propEnabled(property) {
 
 // The following Gradle tasks are used to create a PA/RCA enabled Elasticsearch cluster
 // Pass the -Dtests.enableIT property to Gradle to run ITs
+/**
+ * cloneGitRepo clones the performance-analyzer-rca repo if the -Dtests.enableIT=true flag is passed
+ * to the Gradle JVM
+ */
 task cloneGitRepo(type: GitClone) {
     onlyIf = {
         propEnabled("tests.enableIT")
@@ -213,6 +217,10 @@ task cloneGitRepo(type: GitClone) {
     enabled = !destination.exists() // to clone only once
 }
 
+/**
+ * setupESCluster spins up a local 2 node ES cluster using the enableRca task in the performance-analyzer-rca
+ * repo. The performance-analyzer-rca repo is cloned as part of the cloneGitRepo task.
+ */
 task setupEsCluster() {
     dependsOn(cloneGitRepo)
     onlyIf = {
@@ -227,6 +235,24 @@ task setupEsCluster() {
     }
 }
 
+/**
+ * integTestRunner is a task provided by the ES test framework, which allows us to spin up clients
+ * and test API calls against a local or remote Elasticsearch cluster.
+ *
+ * The simplest way to run this task in a way that "just works" is to invoke
+ * ./gradlew integTest -Dtests.enableIT=true -Dtests.useDockerCluster=true
+ * which will spin up a local 2 node ES cluster on your machine, then execute the test suite against it
+ *
+ * A full list of options is provided below. Check our gradle.properties file for the defaults for
+ * each of these properties.
+ *
+ * -Dtests.rest.cluster the Elasticsearch REST endpoint that test clients should hit
+ * -Dtests.cluster the Elasticsearch transport endpoint that test clients should hit
+ * -Dtests.enableIT a flag to enable integration testing, by default this is false
+ * -Dtests.useDockerCluster if true, spin up a local 2 node cluster before executing tests
+ *        NOTE: if you specify this, don't specify -Dtests.rest.cluster or -Dtests.cluster
+ * -Dtests.pa.port the port number of the PerformanceAnalyzer REST endpoint
+ */
 integTestRunner {
     onlyIf = {
         propEnabled("tests.enableIT")

--- a/gradle.properties
+++ b/gradle.properties
@@ -16,3 +16,12 @@ systemProp.tests.enableIT=false
 
 # The port number for the PerformanceAnalyzer WebService
 systemProp.tests.pa.port=9600
+
+# Whether or not to use https for REST and transport clients
+systemProp.tests.https=false
+
+# The username of the admin user (or any user able to auth requests against opendistro-security)
+# NOTE: this only does something if tests.https is set to true
+systemProp.tests.user=admin
+# The password of the user specified above
+systemProp.tests.password=admin

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/setting/handler/PerformanceAnalyzerClusterSettingHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/setting/handler/PerformanceAnalyzerClusterSettingHandler.java
@@ -11,10 +11,9 @@ public class PerformanceAnalyzerClusterSettingHandler implements ClusterSettingL
     private static final int CLUSTER_SETTING_DISABLED_VALUE = 0;
     private static final int ENABLED_VALUE = 1;
     private static final int MAX_ALLOWED_BIT_POS = Math.min(PerformanceAnalyzerFeatureBits.values().length, Integer.SIZE - 1);
-
-    public static final int RCA_ENABLED_BIT_POS = PerformanceAnalyzerFeatureBits.RCA_BIT.ordinal();
-    public static final int PA_ENABLED_BIT_POS = PerformanceAnalyzerFeatureBits.PA_BIT.ordinal();
-    public static final int LOGGING_ENABLED_BIT_POS = PerformanceAnalyzerFeatureBits.LOGGING_BIT.ordinal();
+    private static final int RCA_ENABLED_BIT_POS = PerformanceAnalyzerFeatureBits.RCA_BIT.ordinal();
+    private static final int PA_ENABLED_BIT_POS = PerformanceAnalyzerFeatureBits.PA_BIT.ordinal();
+    private static final int LOGGING_ENABLED_BIT_POS = PerformanceAnalyzerFeatureBits.LOGGING_BIT.ordinal();
 
     private final PerformanceAnalyzerController controller;
     private final ClusterSettingsManager clusterSettingsManager;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/setting/handler/PerformanceAnalyzerClusterSettingHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/setting/handler/PerformanceAnalyzerClusterSettingHandler.java
@@ -10,10 +10,11 @@ public class PerformanceAnalyzerClusterSettingHandler implements ClusterSettingL
     private static final int BIT_ONE = 1;
     private static final int CLUSTER_SETTING_DISABLED_VALUE = 0;
     private static final int ENABLED_VALUE = 1;
-    private static final int RCA_ENABLED_BIT_POS = PerformanceAnalyzerFeatureBits.RCA_BIT.ordinal();
-    private static final int PA_ENABLED_BIT_POS = PerformanceAnalyzerFeatureBits.PA_BIT.ordinal();
-    private static final int LOGGING_ENABLED_BIT_POS = PerformanceAnalyzerFeatureBits.LOGGING_BIT.ordinal();
     private static final int MAX_ALLOWED_BIT_POS = Math.min(PerformanceAnalyzerFeatureBits.values().length, Integer.SIZE - 1);
+
+    public static final int RCA_ENABLED_BIT_POS = PerformanceAnalyzerFeatureBits.RCA_BIT.ordinal();
+    public static final int PA_ENABLED_BIT_POS = PerformanceAnalyzerFeatureBits.PA_BIT.ordinal();
+    public static final int LOGGING_ENABLED_BIT_POS = PerformanceAnalyzerFeatureBits.LOGGING_BIT.ordinal();
 
     private final PerformanceAnalyzerController controller;
     private final ClusterSettingsManager clusterSettingsManager;
@@ -219,7 +220,7 @@ public class PerformanceAnalyzerClusterSettingHandler implements ClusterSettingL
      * @param bitPosition The position of the bit in the clusterSettingValue
      * @return true if the bit is set, false otherwise.
      */
-    private boolean checkBit(int clusterSettingValue, int bitPosition) {
+    public static boolean checkBit(int clusterSettingValue, int bitPosition) {
         return ((bitPosition < MAX_ALLOWED_BIT_POS) & (clusterSettingValue & (1 << bitPosition)) == ENABLED_VALUE);
     }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/ITConfig.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/ITConfig.java
@@ -1,0 +1,77 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer;
+
+public class ITConfig {
+  // Whether or not to use https clients for the integration tests
+  private boolean https;
+  // The username to use for basic https authentication (if https is specified)
+  private String user;
+  // The password of the user provided above
+  private String password;
+  // The Elasticsearch REST endpoint to initialize clients against of the form $host:$port
+  private String restEndpoint;
+  // The Elasticsearch transport endpoint to initialize clients against of the form $host:$port
+  // see https://discuss.elastic.co/t/transport-client-vs-rest-client/13936 for a synopsis of the
+  // difference between REST and transport endpoints
+  private String transportEndpoint;
+
+  // The port number to use for
+  private int paPort = 9600;
+
+  public ITConfig() {
+    https = Boolean.parseBoolean(System.getProperty("tests.https"));
+    user = System.getProperty("tests.user");
+    password = System.getProperty("tests.password");
+    restEndpoint = System.getProperty("tests.rest.cluster");
+    transportEndpoint = System.getProperty("tests.cluster");
+    String paPortTmp = System.getProperty("tests.paPort");
+    paPort = paPortTmp == null ? paPort : Integer.parseInt(paPortTmp);
+  }
+
+  public boolean isHttps() {
+    return https;
+  }
+
+  public void setHttps(boolean https) {
+    this.https = https;
+  }
+
+  public String getUser() {
+    return user;
+  }
+
+  public void setUser(String user) {
+    this.user = user;
+  }
+
+  public String getPassword() {
+    return password;
+  }
+
+  public void setPassword(String password) {
+    this.password = password;
+  }
+
+  public String getRestEndpoint() {
+    return restEndpoint;
+  }
+
+  public void setRestEndpoint(String restEndpoint) {
+    this.restEndpoint = restEndpoint;
+  }
+
+  public String getTransportEndpoint() {
+    return transportEndpoint;
+  }
+
+  public void setTransportEndpoint(String transportEndpoint) {
+    this.transportEndpoint = transportEndpoint;
+  }
+
+  public int getPaPort() {
+    return paPort;
+  }
+
+  public void setPaPort(int paPort) {
+    this.paPort = paPort;
+  }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerIT.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerIT.java
@@ -1,6 +1,7 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.setting.PerformanceAnalyzerClusterSettings;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.setting.PerformanceAnalyzerClusterSettings.PerformanceAnalyzerFeatureBits;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.setting.handler.PerformanceAnalyzerClusterSettingHandler;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.util.WaitFor;
 import com.fasterxml.jackson.core.type.TypeReference;
@@ -219,8 +220,8 @@ public class PerformanceAnalyzerIT extends ESRestTestCase {
                 });
         Integer state = (Integer) respMap.get("currentPerformanceAnalyzerClusterState");
         Assert.assertTrue("PA and RCA are not enabled on the target cluster!",
-            PerformanceAnalyzerClusterSettingHandler.checkBit(state, PerformanceAnalyzerClusterSettingHandler.PA_ENABLED_BIT_POS) &&
-                PerformanceAnalyzerClusterSettingHandler.checkBit(state, PerformanceAnalyzerClusterSettingHandler.RCA_ENABLED_BIT_POS));
+            PerformanceAnalyzerClusterSettingHandler.checkBit(state, PerformanceAnalyzerFeatureBits.PA_BIT.ordinal()) &&
+                PerformanceAnalyzerClusterSettingHandler.checkBit(state, PerformanceAnalyzerFeatureBits.RCA_BIT.ordinal()));
     }
 
     @Test

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerIT.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerIT.java
@@ -174,12 +174,15 @@ public class PerformanceAnalyzerIT extends ESRestTestCase {
      */
     public Response enableComponent(Component component) throws Exception {
         String endpoint;
-        if (component == Component.PA) {
-            endpoint = "_opendistro/_performanceanalyzer/cluster/config";
-        } else if (component == Component.RCA) {
-            endpoint = "_opendistro/_performanceanalyzer/rca/cluster/config";
-        } else {
-            throw new IllegalArgumentException("Unrecognized component value " + component.toString());
+        switch (component) {
+            case PA:
+                endpoint = "_opendistro/_performanceanalyzer/cluster/config";
+                break;
+            case RCA:
+                endpoint = "_opendistro/_performanceanalyzer/rca/cluster/config";
+                break;
+            default:
+                throw new IllegalArgumentException("Unrecognized component value " + component.toString());
         }
         Request request = new Request("POST", endpoint);
         request.setJsonEntity("{\"enabled\": true}");


### PR DESCRIPTION
*Fixes #, if available:*  #175 

*Description of changes:*
- PerformanceAnalyzerIT is now capable of initializing ES test framework
clients via Basic HTTP Authentication


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
