### PR TITLE
Fix download and doc link in the package description

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -307,10 +307,10 @@ afterEvaluate {
 
         license 'ASL-2.0'
         maintainer 'OpenDistro for Elasticsearch Team <opendistro@amazon.com>'
-        url 'https://opendistro.github.io/elasticsearch/downloads'
+        url 'https://opendistro.github.io/for-elasticsearch/downloads.html'
         summary '''
          Performance Analyzer plugin for OpenDistro for Elasticsearch.
-         Reference documentation can be found at https://opendistro.github.io/elasticsearch/docs.
+         Reference documentation can be found at https://opendistro.github.io/for-elasticsearch-docs/.
     '''.stripIndent().replace('\n', ' ').trim()
     }
 


### PR DESCRIPTION
*Fixes #, if available:*
A community user found a bug in the links stated in package descriptions. check the post [here](https://discuss.opendistrocommunity.dev/t/unable-to-setup-apt-repo-for-opendistro-in-our-org/3124)

*Description of changes:*
Fix download and doc link in the package description

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
