### PR TITLE
Enabling RCA framework by default

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/PerformanceAnalyzerController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/PerformanceAnalyzerController.java
@@ -30,7 +30,7 @@ public class PerformanceAnalyzerController {
     private boolean batchMetricsEnabled;
     private volatile int shardsPerCollection;
     private static final boolean paEnabledDefaultValue = false;
-    private static final boolean rcaEnabledDefaultValue = false;
+    private static final boolean rcaEnabledDefaultValue = true;
     private static final boolean loggingEnabledDefaultValue = false;
     private static final boolean batchMetricsEnabledDefaultValue = false;
     private final ScheduledMetricCollectorsExecutor scheduledMetricCollectorsExecutor;


### PR DESCRIPTION
*Fixes #, if available:* https://github.com/opendistro-for-elasticsearch/performance-analyzer/issues/208

*Description of changes:* Enable RCA Framework by default.
[initRcaStateFromConf()](https://github.com/opendistro-for-elasticsearch/performance-analyzer/blame/080a62b4efc6eb30f23fa7bc3654b8032f133217/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/PerformanceAnalyzerController.java#L175) initializes the RCA Conf file `rca_enabled.conf`, which is used by the RCA controller to enable/disable the framework.

As part of bootstrap, the `initRcaStateFromConf()` on not finding the `rca_enabled.conf` file, uses the default value for rcaEnabled. This code changes updates this value to 'true' from 'false'. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
