### PR TITLE
Publish shard state metrics

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerPlugin.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerPlugin.java
@@ -15,6 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.ShardStateCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.overrides.ConfigOverridesWrapper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.setting.handler.ConfigOverridesClusterSettingHandler;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.CacheConfigMetricsCollector;
@@ -195,6 +196,7 @@ public final class PerformanceAnalyzerPlugin extends Plugin implements ActionPlu
                 NodeStatsFixedShardsMetricsCollector(performanceAnalyzerController));
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new MasterServiceMetrics());
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new MasterServiceEventMetrics());
+        scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new ShardStateCollector());
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new DisksCollector());
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new NetworkInterfaceCollector());
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(StatsCollector.instance());

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerPlugin.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerPlugin.java
@@ -196,10 +196,10 @@ public final class PerformanceAnalyzerPlugin extends Plugin implements ActionPlu
                 NodeStatsFixedShardsMetricsCollector(performanceAnalyzerController));
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new MasterServiceMetrics());
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new MasterServiceEventMetrics());
-        scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new ShardStateCollector());
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new DisksCollector());
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new NetworkInterfaceCollector());
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(StatsCollector.instance());
+        scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new ShardStateCollector());
         scheduledMetricCollectorsExecutor.start();
 
         EventLog eventLog = new EventLog();

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerPlugin.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerPlugin.java
@@ -199,7 +199,8 @@ public final class PerformanceAnalyzerPlugin extends Plugin implements ActionPlu
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new DisksCollector());
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new NetworkInterfaceCollector());
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(StatsCollector.instance());
-        scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new ShardStateCollector());
+        scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new ShardStateCollector(
+                performanceAnalyzerController,configOverridesWrapper));
         scheduledMetricCollectorsExecutor.start();
 
         EventLog eventLog = new EventLog();

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardStateCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardStateCollector.java
@@ -1,0 +1,132 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.ESResources;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsProcessor;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.cluster.ClusterState;
+import org.elasticsearch.cluster.routing.ShardRouting;
+import org.elasticsearch.cluster.routing.ShardRoutingState;
+import org.jooq.tools.StringUtils;
+
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics.SHARD_PRIMARY;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics.SHARD_REPLICA;
+
+public class ShardStateCollector extends PerformanceAnalyzerMetricsCollector implements MetricsProcessor {
+    public static final int SAMPLING_TIME_INTERVAL = MetricsConfiguration.CONFIG_MAP.get(ShardStateCollector.class).samplingInterval;
+    private static final Logger LOG = LogManager.getLogger(ShardStateCollector.class);
+    private static final int KEYS_PATH_LENGTH = 0;
+    private StringBuilder value;
+
+    public ShardStateCollector() {
+        super(SAMPLING_TIME_INTERVAL, "ShardsStateCollector");
+        value = new StringBuilder();
+    }
+
+    @Override
+    void collectMetrics( long startTime) {
+        if (ESResources.INSTANCE.getClusterService() == null) {
+            return;
+        }
+        ClusterState clusterState = ESResources.INSTANCE.getClusterService().state();
+
+        try {
+            value.setLength(0);
+            value.append(PerformanceAnalyzerMetrics.getJsonCurrentMilliSeconds())
+                    .append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
+            for(ShardRouting shard : clusterState.routingTable().allShards()) {
+                String nodeName = StringUtils.EMPTY;
+                if (shard.assignedToNode()) {
+                    nodeName = clusterState.nodes().get(shard.currentNodeId()).getName();
+                }
+                value
+                        .append(new ShardStateMetrics(
+                                shard.getIndexName(),
+                                shard.getId(),
+                                shard.primary()?SHARD_PRIMARY:SHARD_REPLICA,
+                                nodeName,
+                                shard.state() == ShardRoutingState.STARTED?1:0,
+                                shard.state() == ShardRoutingState.INITIALIZING?1:0,
+                                shard.state() == ShardRoutingState.UNASSIGNED?1:0)
+                                .serialize())
+                        .append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
+            }
+            saveMetricValues(value.toString(), startTime);
+
+        } catch (Exception ex) {
+            LOG.debug("Exception in Collecting Shard Metrics: {} for startTime {}", () -> ex.toString(),
+                    () -> startTime);
+        }
+    }
+
+    @Override
+    public String getMetricsPath(long startTime, String... keysPath) {
+        if (keysPath.length != KEYS_PATH_LENGTH) {
+            throw new RuntimeException("keys length should be " + KEYS_PATH_LENGTH);
+        }
+
+        return PerformanceAnalyzerMetrics.generatePath(startTime, PerformanceAnalyzerMetrics.sShardStatePath);
+    }
+
+    public static class ShardStateMetrics extends MetricStatus {
+
+        private final String indexName;
+        private final int shardId;
+        private final String shardType;
+        private final String nodeName;
+        private final int activeShardState;
+        private final int initializingShardState;
+        private final int unassignedShardState;
+
+        public ShardStateMetrics(String indexName, int shardId, String shardType, String nodeName, int activeShardState,
+                               int initializingShardState, int unassignedShardState) {
+            this.indexName = indexName;
+            this.shardId = shardId;
+            this.shardType = shardType;
+            this.nodeName = nodeName;
+            this.activeShardState = activeShardState;
+            this.initializingShardState = initializingShardState;
+            this.unassignedShardState = unassignedShardState;
+        }
+
+        @JsonProperty(AllMetrics.CommonDimension.Constants.INDEX_NAME_VALUE)
+        public String getIndexName() {
+            return indexName;
+        }
+
+        @JsonProperty(AllMetrics.CommonDimension.Constants.SHARDID_VALUE)
+        public int getShardId() {
+            return shardId;
+        }
+
+        @JsonProperty(AllMetrics.ShardStateDimension.Constants.SHARD_TYPE)
+        public String getShardType() {
+            return shardType;
+        }
+
+        @JsonProperty(AllMetrics.ShardStateDimension.Constants.NODE_NAME)
+        public String  getNodeName() {
+            return nodeName;
+        }
+
+        @JsonProperty(AllMetrics.ShardStateValue.Constants.SHARD_STATE_ACTIVE)
+        public int getActiveShardState() {
+            return activeShardState;
+        }
+
+        @JsonProperty(AllMetrics.ShardStateValue.Constants.SHARD_STATE_INITIALIZING)
+        public int getInitializingShardState() {
+            return initializingShardState;
+        }
+
+        @JsonProperty(AllMetrics.ShardStateValue.Constants.SHARD_STATE_UNASSIGNED)
+        public int getUnassignedShardState() {
+            return unassignedShardState;
+        }
+    }
+
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardStateCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardStateCollector.java
@@ -1,10 +1,13 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.ESResources;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsProcessor;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.ExceptionsAndErrors;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.WriterMetrics;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
@@ -33,6 +36,7 @@ public class ShardStateCollector extends PerformanceAnalyzerMetricsCollector imp
 
     @Override
     void collectMetrics( long startTime) {
+        long mCurrT = System.currentTimeMillis();
         if (ESResources.INSTANCE.getClusterService() == null) {
             return;
         }
@@ -70,8 +74,12 @@ public class ShardStateCollector extends PerformanceAnalyzerMetricsCollector imp
             if(inActiveShard) {
                 saveMetricValues(value.toString(), startTime);
             }
-
+            PerformanceAnalyzerApp.ERRORS_AND_EXCEPTIONS_AGGREGATOR.updateStat(
+                    WriterMetrics.SHARD_STATE_COLLECTOR_EXECUTION_TIME, "",
+                    System.currentTimeMillis() - mCurrT);
         } catch (Exception ex) {
+            PerformanceAnalyzerApp.ERRORS_AND_EXCEPTIONS_AGGREGATOR.updateStat(
+                    ExceptionsAndErrors.SHARD_STATE_COLLECTOR_ERROR, "", 1);
             LOG.debug("Exception in Collecting Shard Metrics: {} for startTime {}", () -> ex.toString(),
                     () -> startTime);
         }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardStateCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardStateCollector.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.ESResources;
@@ -20,8 +35,8 @@ import org.jooq.tools.json.JSONObject;
 
 import java.util.List;
 
-import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics.SHARD_PRIMARY;
-import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics.SHARD_REPLICA;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ShardType.SHARD_PRIMARY;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ShardType.SHARD_REPLICA;
 
 public class ShardStateCollector extends PerformanceAnalyzerMetricsCollector implements MetricsProcessor {
     public static final int SAMPLING_TIME_INTERVAL = MetricsConfiguration.CONFIG_MAP.get(ShardStateCollector.class).samplingInterval;
@@ -62,7 +77,7 @@ public class ShardStateCollector extends PerformanceAnalyzerMetricsCollector imp
                                 .append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor)
                                 .append(new ShardStateMetrics(
                                         shard.getId(),
-                                        shard.primary() ? SHARD_PRIMARY : SHARD_REPLICA,
+                                        shard.primary() ? SHARD_PRIMARY.toString() : SHARD_REPLICA.toString(),
                                         nodeName,
                                         shard.state().name())
                                         .serialize());

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardStateCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardStateCollector.java
@@ -17,6 +17,8 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.ESResources;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PerformanceAnalyzerController;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.overrides.ConfigOverridesWrapper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsProcessor;
@@ -42,15 +44,23 @@ public class ShardStateCollector extends PerformanceAnalyzerMetricsCollector imp
     public static final int SAMPLING_TIME_INTERVAL = MetricsConfiguration.CONFIG_MAP.get(ShardStateCollector.class).samplingInterval;
     private static final Logger LOG = LogManager.getLogger(ShardStateCollector.class);
     private static final int KEYS_PATH_LENGTH = 0;
+    private final ConfigOverridesWrapper configOverridesWrapper;
+    private final PerformanceAnalyzerController controller;
     private StringBuilder value;
 
-    public ShardStateCollector() {
+    public ShardStateCollector(PerformanceAnalyzerController controller,
+                               ConfigOverridesWrapper configOverridesWrapper) {
         super(SAMPLING_TIME_INTERVAL, "ShardsStateCollector");
         value = new StringBuilder();
+        this.controller = controller;
+        this.configOverridesWrapper = configOverridesWrapper;
     }
 
     @Override
     void collectMetrics( long startTime) {
+        if(!controller.isCollectorEnabled(configOverridesWrapper, getCollectorName())) {
+            return;
+        }
         long mCurrT = System.currentTimeMillis();
         if (ESResources.INSTANCE.getClusterService() == null) {
             return;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardStateCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardStateCollector.java
@@ -74,7 +74,7 @@ public class ShardStateCollector extends PerformanceAnalyzerMetricsCollector imp
             if(inActiveShard) {
                 saveMetricValues(value.toString(), startTime);
             }
-            PerformanceAnalyzerApp.ERRORS_AND_EXCEPTIONS_AGGREGATOR.updateStat(
+            PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(
                     WriterMetrics.SHARD_STATE_COLLECTOR_EXECUTION_TIME, "",
                     System.currentTimeMillis() - mCurrT);
         } catch (Exception ex) {

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/PerformanceAnalyzerController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/PerformanceAnalyzerController.java
@@ -5,8 +5,10 @@ import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.List;
 import java.util.Scanner;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.overrides.ConfigOverridesWrapper;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -256,5 +258,14 @@ public class PerformanceAnalyzerController {
                 LOG.error(ex.toString(), ex);
             }
         });
+    }
+
+    public boolean isCollectorEnabled(ConfigOverridesWrapper configOverridesWrapper, String collectorName) {
+        List<String> enabledCollectorsList = configOverridesWrapper.getCurrentClusterConfigOverrides().getEnable()
+                .getCollectors();
+        if(enabledCollectorsList.contains(collectorName)) {
+            return true;
+        }
+        return false;
     }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/PerformanceAnalyzerController.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/PerformanceAnalyzerController.java
@@ -261,11 +261,11 @@ public class PerformanceAnalyzerController {
     }
 
     public boolean isCollectorEnabled(ConfigOverridesWrapper configOverridesWrapper, String collectorName) {
+        if(configOverridesWrapper == null) {
+            return false;
+        }
         List<String> enabledCollectorsList = configOverridesWrapper.getCurrentClusterConfigOverrides().getEnable()
                 .getCollectors();
-        if(enabledCollectorsList.contains(collectorName)) {
-            return true;
-        }
-        return false;
+        return enabledCollectorsList.contains(collectorName) ? true: false;
     }
 }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/util/Utils.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/util/Utils.java
@@ -17,6 +17,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.util;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.ESResources;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.CacheConfigMetricsCollector;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.ShardStateCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.CircuitBreakerCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MasterServiceEventMetrics;
@@ -51,7 +52,7 @@ public class Utils {
         MetricsConfiguration.CONFIG_MAP.put(NodeStatsFixedShardsMetricsCollector.class, cdefault);
         MetricsConfiguration.CONFIG_MAP.put(MasterServiceEventMetrics.class, new MetricsConfiguration.MetricConfig(1000, 0, 0));
         MetricsConfiguration.CONFIG_MAP.put(MasterServiceMetrics.class, cdefault);
-        
+        MetricsConfiguration.CONFIG_MAP.put(ShardStateCollector.class, cdefault);
     }
 
     // These methods are utility functions for the Node Stat Metrics Collectors. These methods are used by both the all

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardStateCollectorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardStateCollectorTest.java
@@ -1,0 +1,36 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.CustomMetricsLocationTestBase;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSettings;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@Ignore
+public class ShardStateCollectorTest extends CustomMetricsLocationTestBase {
+
+    @Test
+    public void testShardsStateMetrics() {
+        MetricsConfiguration.CONFIG_MAP.put(ShardStateCollector.class, MetricsConfiguration.cdefault);
+        System.setProperty("performanceanalyzer.metrics.log.enabled", "False");
+        long startTimeInMills = 1153721339;
+        ShardStateCollector shardsStateCollector = new ShardStateCollector();
+        shardsStateCollector.saveMetricValues("shard_state_metrics", startTimeInMills);
+        String fetchedValue = PerformanceAnalyzerMetrics.getMetric(PluginSettings.instance().getMetricsLocation()
+                + PerformanceAnalyzerMetrics.getTimeInterval(startTimeInMills)+"/shard_state_metrics/");
+        PerformanceAnalyzerMetrics.removeMetrics(PluginSettings.instance().getMetricsLocation()
+                + PerformanceAnalyzerMetrics.getTimeInterval(startTimeInMills));
+        assertEquals("shard_state_metrics", fetchedValue);
+
+        try {
+            shardsStateCollector.saveMetricValues("shard_state_metrics", startTimeInMills, "123");
+            assertTrue("Negative scenario test: Should have been a RuntimeException", true);
+        } catch (RuntimeException ex) {
+            //- expecting exception...1 values passed; 0 expected
+        }
+    }
+}

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardStateCollectorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardStateCollectorTest.java
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.CustomMetricsLocationTestBase;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardStateCollectorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardStateCollectorTest.java
@@ -4,13 +4,11 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.CustomMetricsLoca
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSettings;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
-import org.junit.Ignore;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
-@Ignore
 public class ShardStateCollectorTest extends CustomMetricsLocationTestBase {
 
     @Test
@@ -34,3 +32,4 @@ public class ShardStateCollectorTest extends CustomMetricsLocationTestBase {
         }
     }
 }
+

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardStateCollectorTest.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardStateCollectorTest.java
@@ -16,10 +16,13 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.CustomMetricsLocationTestBase;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PerformanceAnalyzerController;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSettings;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.overrides.ConfigOverridesWrapper;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
 import org.junit.Test;
+import org.mockito.Mockito;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -31,7 +34,11 @@ public class ShardStateCollectorTest extends CustomMetricsLocationTestBase {
         MetricsConfiguration.CONFIG_MAP.put(ShardStateCollector.class, MetricsConfiguration.cdefault);
         System.setProperty("performanceanalyzer.metrics.log.enabled", "False");
         long startTimeInMills = 1153721339;
-        ShardStateCollector shardsStateCollector = new ShardStateCollector();
+        PerformanceAnalyzerController controller = Mockito.mock(PerformanceAnalyzerController.class);
+        ConfigOverridesWrapper configOverrides = Mockito.mock(ConfigOverridesWrapper.class);
+        Mockito.when(controller.isCollectorEnabled(configOverrides, "ShardStateCollector"))
+                .thenReturn(true);
+        ShardStateCollector shardsStateCollector = new ShardStateCollector(controller, configOverrides);
         shardsStateCollector.saveMetricValues("shard_state_metrics", startTimeInMills);
         String fetchedValue = PerformanceAnalyzerMetrics.getMetric(PluginSettings.instance().getMetricsLocation()
                 + PerformanceAnalyzerMetrics.getTimeInterval(startTimeInMills)+"/shard_state_metrics/");


### PR DESCRIPTION
*Fixes #, if available: https://github.com/opendistro-for-elasticsearch/performance-analyzer/issues/213*

*Description of changes:*
This change will start publishing shard state - Initializing, Unassigned and Relocating for each shard. We have not published Active shards to save space.

Testing
1. ./gradlew test
```
SUCCESS: Executed 455 tests in 41m 55s (1 skipped)

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.5/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 42m 22s
11 actionable tasks: 2 executed, 9 up-to-date
```

2. Tested using docker.

Tmp File - 
```
^shard_state_metrics
{"current_time":1602500493586}
{"IndexName":pmc}
{"ShardID":2,"ShardType":"p","NodeName":"elasticsearch2","Shard_State":"UNASSIGNED"}
{"ShardID":4,"ShardType":"p","NodeName":"elasticsearch2","Shard_State":"INITIALIZING"}
{"IndexName":pmc1}
{"ShardID":1,"ShardType":"p","NodeName":"elasticsearch1","Shard_State":"UNASSIGNED"}
{"ShardID":0,"ShardType":"p","NodeName":"elasticsearch2","Shard_State":"UNASSIGNED"}
$
```

Table created
```
sqlite> .tables
Shard_State
```

Schema of the table
```
sqlite> .schema Shard_State
CREATE TABLE Shard_State(IndexName varchar null, ShardID varchar null, ShardType varchar null, NodeName varchar null, Shard_State varchar null, sum double null, avg double null, min double null, max double null);
```

Content of the table
```
sqlite> select * from Shard_State;
pmc|4|p|elasticsearch1|UNASSIGNED|1.0|1.0|1.0|1.0
pmc|2|p|elasticsearch2|INITIALIZING|1.0|1.0|1.0|1.0
pmc1|1|p|elasticsearch2|UNASSIGNED|1.0|1.0|1.0|1.0
pmc1|0|p|elasticsearch1|UNASSIGNED|1.0|1.0|1.0|1.0
```
Rest API
```
arpitamt@c4b301d5bc1f ~> curl -XGET "localhost:9600/_opendistro/_performanceanalyzer/metrics?metrics=Shard_State&agg=avg&dim=Shard_State&nodes=all" | python -m json.tool
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100   188  100   188    0     0     22      0  0:00:08  0:00:08 --:--:--    45
{
    "id3qQArxRPSA2EHbEfPlew": {
        "timestamp": 1602771645000,
        "data": {
            "fields": [
                {
                    "name": "Shard_State",
                    "type": "VARCHAR"
                },
                {
                    "name": "Shard_State",
                    "type": "DOUBLE"
                }
            ],
            "records": [
                [
                    "UNASSIGNED",
                    0.0
                ]
            ]
        }
    }
}
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
