### PR TITLE
Adding the Support to Proxy the call over to the _agent for Actions API

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/http_action/config/PerformanceAnalyzerResourceProvider.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/http_action/config/PerformanceAnalyzerResourceProvider.java
@@ -56,7 +56,7 @@ public class PerformanceAnalyzerResourceProvider extends BaseRestHandler {
 
   private String portNumber;
   private final boolean isHttpsEnabled;
-  private static Set<String> SUPPORTED_REDIRECTIONS = ImmutableSet.of("rca", "metrics", "batch");
+  private static Set<String> SUPPORTED_REDIRECTIONS = ImmutableSet.of("rca", "metrics", "batch", "actions");
 
   @Inject
   public PerformanceAnalyzerResourceProvider(Settings settings, RestController controller) {

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/PerformanceAnalyzerClusterSettingHandlerTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/PerformanceAnalyzerClusterSettingHandlerTests.java
@@ -25,7 +25,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
 
-public class PerformanceAnalyzerClusterSettingHandlerTest {
+public class PerformanceAnalyzerClusterSettingHandlerTests {
     private static final Boolean DISABLED_STATE = Boolean.FALSE;
     private static final Boolean ENABLED_STATE = Boolean.TRUE;
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/http_action/config/PerformanceAnalyzerResourceProviderTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/http_action/config/PerformanceAnalyzerResourceProviderTests.java
@@ -43,7 +43,7 @@ import static org.mockito.MockitoAnnotations.initMocks;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({PluginSettings.class})
 @SuppressStaticInitializationFor({"PluginSettings"})
-public class PerformanceAnalyzerResourceProviderTest {
+public class PerformanceAnalyzerResourceProviderTests {
   @Mock
   RestController mockRestController;
   PerformanceAnalyzerResourceProvider performanceAnalyzerRp;
@@ -133,6 +133,17 @@ public class PerformanceAnalyzerResourceProviderTest {
     assertEquals(new URL(expectedResponseUri), actualResponseURI);
   }
 
+  private void assertAgentUriWithActionsRedirection(final String protocolScheme) throws IOException {
+    initPerformanceAnalyzerResourceProvider(protocolScheme.equals("https://"));
+
+    String requestUri = protocolScheme + "localhost:9200/_opendistro/_performanceanalyzer/_agent/actions";
+    String expectedResponseUri = protocolScheme + "localhost:9650/_opendistro/_performanceanalyzer/actions";
+
+    RestRequest restRequest = generateRestRequest(requestUri, "actions");
+    URL actualResponseURI = performanceAnalyzerRp.getAgentUri(restRequest);
+    assertEquals(new URL(expectedResponseUri), actualResponseURI);
+  }
+
 
   @Test
   public void testGetAgentUri_WithHttp_WithMetricRedirection() throws Exception {
@@ -162,6 +173,16 @@ public class PerformanceAnalyzerResourceProviderTest {
   @Test
   public void testGetAgentUri_WithHttps_WithBatchRedirection() throws Exception {
     assertAgentUriWithBatchRedirection("https://");
+  }
+
+  @Test
+  public void testGetAgentUri_WithHttp_WithActionsRedirection() throws Exception {
+    assertAgentUriWithActionsRedirection("http://");
+  }
+
+  @Test
+  public void testGetAgentUri_WithHttps_WithActionsRedirection() throws Exception {
+    assertAgentUriWithActionsRedirection("https://");
   }
 
   @Test

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader_writer_shared/EventLogFileHandlerTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader_writer_shared/EventLogFileHandlerTests.java
@@ -14,7 +14,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.writer.EventLogQu
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
-public class EventLogFileHandlerTest {
+public class EventLogFileHandlerTests {
     @Mock
     private PerformanceAnalyzerController mockController;
 


### PR DESCRIPTION
*Fixes #, if available:* Adding the Support to Proxy the call over to the _agent for Actions API

*Description of changes:* Add the proxy support as well as enable tests which were not enabled due to `Test` file name instead of a `Tests` filename.  


*Tests:*

=======================================

> Task :spotbugsMain
Warning at xsl:variable on line 348 column 57 of default.xsl:
  SXWN9001: A variable with no following sibling instructions has no effect
Warning at xsl:variable on line 351 column 57 of default.xsl:
  SXWN9001: A variable with no following sibling instructions has no effect

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.0.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 14s



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
