### PR TITLE
Master throttling metric

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerPlugin.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerPlugin.java
@@ -74,6 +74,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.DisksC
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.HeapMetricsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MasterServiceEventMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MasterServiceMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MasterThrottlingMetricsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MetricsPurgeActivity;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.NetworkInterfaceCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.NodeDetailsCollector;
@@ -194,6 +195,7 @@ public final class PerformanceAnalyzerPlugin extends Plugin implements ActionPlu
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new
                 NodeStatsFixedShardsMetricsCollector(performanceAnalyzerController));
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new MasterServiceMetrics());
+        scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new MasterThrottlingMetricsCollector());
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new MasterServiceEventMetrics());
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new DisksCollector());
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new NetworkInterfaceCollector());

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/MasterThrottlingMetricsCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/MasterThrottlingMetricsCollector.java
@@ -1,0 +1,112 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.ESResources;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsProcessor;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.elasticsearch.cluster.service.MasterService;
+
+import java.lang.reflect.Method;
+
+public class MasterThrottlingMetricsCollector extends PerformanceAnalyzerMetricsCollector implements MetricsProcessor {
+
+    public static final int SAMPLING_TIME_INTERVAL =
+            MetricsConfiguration.CONFIG_MAP.get(MasterThrottlingMetricsCollector.class).samplingInterval;
+    private static final Logger LOG = LogManager.getLogger(MasterThrottlingMetricsCollector.class);
+    private static final int KEYS_PATH_LENGTH = 0;
+    private static final String MASTER_THROTTLING_RETRY_LISTENER_PATH =
+            "org.elasticsearch.action.support.master.MasterThrottlingRetryListener";
+    private static final String THROTTLED_PENDING_TASK_COUNT_METHOD_NAME = "numberOfThrottledPendingTasks";
+    private static final String RETRYING_TASK_COUNT_METHOD_NAME = "getRetryingTasksCount";
+    private StringBuilder value;
+
+    public MasterThrottlingMetricsCollector() {
+        super(SAMPLING_TIME_INTERVAL, "MasterThrottlingMetricsCollector");
+        value = new StringBuilder();
+    }
+
+    @Override
+    void collectMetrics(long startTime) {
+        try {
+            if (ESResources.INSTANCE.getClusterService() == null
+                    || ESResources.INSTANCE.getClusterService().getMasterService() == null) {
+                return;
+            }
+            if(!isMasterThrottlingFeatureAvailable()) {
+                LOG.error("master throttling is not available");
+                return;
+            }
+
+            value.setLength(0);
+            value.append(PerformanceAnalyzerMetrics.getJsonCurrentMilliSeconds())
+                    .append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
+            value.append(new MasterThrottlingMetrics(
+                    getRetryingPendingTaskCount(),
+                    getTotalMasterThrottledTaskCount()).serialize());
+
+            saveMetricValues(value.toString(), startTime);
+
+        } catch (Exception ex) {
+            LOG.debug("Exception in Collecting Master Throttling Metrics: {} for startTime {}", () -> ex.toString(), () -> startTime);
+        }
+    }
+
+    private boolean isMasterThrottlingFeatureAvailable() {
+        Class throttlingRetryListener = null;
+        Method getThrottledTasksCount = null;
+        try {
+            throttlingRetryListener = Class.forName(MASTER_THROTTLING_RETRY_LISTENER_PATH);
+            getThrottledTasksCount = MasterService.class.getMethod(THROTTLED_PENDING_TASK_COUNT_METHOD_NAME);
+        } catch (ClassNotFoundException | NoSuchMethodException e) {
+            return false;
+        }
+
+        if(throttlingRetryListener == null || getThrottledTasksCount == null){
+            return false;
+        }
+        return true;
+    }
+
+    private long getTotalMasterThrottledTaskCount() throws Exception {
+        Method method = MasterService.class.getMethod(THROTTLED_PENDING_TASK_COUNT_METHOD_NAME);
+        return (long) method.invoke(ESResources.INSTANCE.getClusterService().getMasterService());
+    }
+
+    private long getRetryingPendingTaskCount() throws Exception {
+        Method method = Class.forName(MASTER_THROTTLING_RETRY_LISTENER_PATH).getMethod(RETRYING_TASK_COUNT_METHOD_NAME);
+        return (long) method.invoke(null);
+    }
+
+    @Override
+    public String getMetricsPath(long startTime, String... keysPath) {
+        if (keysPath.length != KEYS_PATH_LENGTH) {
+            throw new RuntimeException("keys length should be " + KEYS_PATH_LENGTH);
+        }
+
+        return PerformanceAnalyzerMetrics.generatePath(startTime, PerformanceAnalyzerMetrics.sMasterThrottledTasksPath);
+    }
+
+    public static class MasterThrottlingMetrics extends MetricStatus {
+        private final long retryingTaskCount;
+        private final long throttledPendingTasksCount;
+
+        public MasterThrottlingMetrics(long retryingTaskCount, long throttledPendingTasksCount) {
+            this.retryingTaskCount = retryingTaskCount;
+            this.throttledPendingTasksCount = throttledPendingTasksCount;
+        }
+
+        @JsonProperty(AllMetrics.MasterThrottlingValue.Constants.RETRYING_TASK_COUNT)
+        public long getRetryingTaskCount() {
+            return retryingTaskCount;
+        }
+
+        @JsonProperty(AllMetrics.MasterThrottlingValue.Constants.THROTTLED_PENDING_TASK_COUNT)
+        public long getThrottledPendingTasksCount() {
+            return throttledPendingTasksCount;
+        }
+    }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/MasterThrottlingMetricsCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/MasterThrottlingMetricsCollector.java
@@ -22,7 +22,7 @@ public class MasterThrottlingMetricsCollector extends PerformanceAnalyzerMetrics
             "org.elasticsearch.action.support.master.MasterThrottlingRetryListener";
     private static final String THROTTLED_PENDING_TASK_COUNT_METHOD_NAME = "numberOfThrottledPendingTasks";
     private static final String RETRYING_TASK_COUNT_METHOD_NAME = "getRetryingTasksCount";
-    private StringBuilder value;
+    private final StringBuilder value;
 
     public MasterThrottlingMetricsCollector() {
         super(SAMPLING_TIME_INTERVAL, "MasterThrottlingMetricsCollector");
@@ -37,7 +37,7 @@ public class MasterThrottlingMetricsCollector extends PerformanceAnalyzerMetrics
                 return;
             }
             if(!isMasterThrottlingFeatureAvailable()) {
-                LOG.error("master throttling is not available");
+                LOG.debug("Master Throttling Feature is not available for this domain");
                 return;
             }
 
@@ -56,16 +56,10 @@ public class MasterThrottlingMetricsCollector extends PerformanceAnalyzerMetrics
     }
 
     private boolean isMasterThrottlingFeatureAvailable() {
-        Class throttlingRetryListener = null;
-        Method getThrottledTasksCount = null;
         try {
-            throttlingRetryListener = Class.forName(MASTER_THROTTLING_RETRY_LISTENER_PATH);
-            getThrottledTasksCount = MasterService.class.getMethod(THROTTLED_PENDING_TASK_COUNT_METHOD_NAME);
+            Class.forName(MASTER_THROTTLING_RETRY_LISTENER_PATH);
+            MasterService.class.getMethod(THROTTLED_PENDING_TASK_COUNT_METHOD_NAME);
         } catch (ClassNotFoundException | NoSuchMethodException e) {
-            return false;
-        }
-
-        if(throttlingRetryListener == null || getThrottledTasksCount == null){
             return false;
         }
         return true;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/util/Utils.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/util/Utils.java
@@ -21,6 +21,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsCo
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.CircuitBreakerCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MasterServiceEventMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MasterServiceMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MasterThrottlingMetricsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.NodeDetailsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.NodeStatsAllShardsMetricsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.NodeStatsFixedShardsMetricsCollector;
@@ -52,6 +53,7 @@ public class Utils {
         MetricsConfiguration.CONFIG_MAP.put(MasterServiceEventMetrics.class, new MetricsConfiguration.MetricConfig(1000, 0, 0));
         MetricsConfiguration.CONFIG_MAP.put(MasterServiceMetrics.class, cdefault);
         
+        MetricsConfiguration.CONFIG_MAP.put(MasterThrottlingMetricsCollector.class, cdefault);
     }
 
     // These methods are utility functions for the Node Stat Metrics Collectors. These methods are used by both the all

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/MasterThrottlingMetricsCollectorTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/MasterThrottlingMetricsCollectorTests.java
@@ -1,3 +1,18 @@
+/*
+ *  Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License").
+ *  You may not use this file except in compliance with the License.
+ *  A copy of the License is located at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  or in the "license" file accompanying this file. This file is distributed
+ *  on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ *  express or implied. See the License for the specific language governing
+ *  permissions and limitations under the License.
+ */
+
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.CustomMetricsLocationTestBase;

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/MasterThrottlingMetricsCollectorTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/MasterThrottlingMetricsCollectorTests.java
@@ -1,0 +1,38 @@
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.CustomMetricsLocationTestBase;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.Event;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class MasterThrottlingMetricsCollectorTests extends CustomMetricsLocationTestBase {
+
+    @Test
+    public void testMasterThrottlingMetrics() {
+        MetricsConfiguration.CONFIG_MAP.put(MasterThrottlingMetricsCollector.class, MetricsConfiguration.cdefault);
+        System.setProperty("performanceanalyzer.metrics.log.enabled", "False");
+
+        long startTimeInMills = 1153721339;
+        MasterThrottlingMetricsCollector throttlingMetricsCollectorCollector = new MasterThrottlingMetricsCollector();
+        throttlingMetricsCollectorCollector.saveMetricValues("testMetric", startTimeInMills);
+
+        List<Event> metrics =  new ArrayList<>();
+        PerformanceAnalyzerMetrics.metricQueue.drainTo(metrics);
+        assertEquals(1, metrics.size());
+        assertEquals("testMetric", metrics.get(0).value);
+
+        try {
+            throttlingMetricsCollectorCollector.saveMetricValues("throttled_pending_tasks", startTimeInMills, "123");
+            assertTrue("Negative scenario test: Should have been a RuntimeException", true);
+        } catch (RuntimeException ex) {
+            //- expecting exception...1 values passed; 0 expected
+        }
+    }
+}


### PR DESCRIPTION
*Description of changes:*
Code change is for Master Throttling of Pending task. It will publish two metric 1) Total throttled tasks at master node 2) Number of task on which data node is actively retrying. This feature is yet to be contributed to Opensource ES. I have added the check for availability of this feature in collector so building with or without this feature will pass. If this feature is not available then collector will simply return.


PR of this was mistakenly merged before approval. Raised same PR again.
Old PR: https://github.com/opendistro-for-elasticsearch/performance-analyzer/pull/217

Testing

    /gradlew test Successful
    Tested in test domain by replacing JAR.

Tmp file

`^master_throttling_metrics
{"current_time":1602617137529}
{"Data_RetryingPendingTasksCount":0,"Master_ThrottledPendingTasksCount":0}$`

Verified metric from table

`sqlite> select * from Master_ThrottledPendingTasksCount;
0.0|0.0|0.0|0.0`




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
