### PR TITLE
Enable disable collectors

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/setting/handler/ConfigOverridesClusterSettingHandler.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/setting/handler/ConfigOverridesClusterSettingHandler.java
@@ -112,10 +112,10 @@ public class ConfigOverridesClusterSettingHandler implements ClusterSettingListe
                 .orElseGet(ConfigOverrides.Overrides::new);
         ConfigOverrides.Overrides optionalNewDisable = Optional.ofNullable(other.getDisable())
                 .orElseGet(ConfigOverrides.Overrides::new);
-
         mergeRcas(merged, optionalCurrentEnabled, optionalNewEnable, optionalCurrentDisabled, optionalNewDisable);
         mergeDeciders(merged, optionalCurrentEnabled, optionalNewEnable, optionalCurrentDisabled, optionalNewDisable);
         mergeActions(merged, optionalCurrentEnabled, optionalNewEnable, optionalCurrentDisabled, optionalNewDisable);
+        mergeCollectors(merged, optionalCurrentEnabled, optionalNewEnable, optionalCurrentDisabled, optionalNewDisable);
 
         return merged;
     }
@@ -181,6 +181,29 @@ public class ConfigOverridesClusterSettingHandler implements ClusterSettingListe
 
         merged.getEnable().setActions(mergedActionsEnabled);
         merged.getDisable().setActions(mergedActionsDisabled);
+    }
+
+    private void mergeCollectors(final ConfigOverrides merged,
+                              final ConfigOverrides.Overrides baseEnabled,
+                              final ConfigOverrides.Overrides newEnabled,
+                              final ConfigOverrides.Overrides baseDisabled,
+                              final ConfigOverrides.Overrides newDisabled) {
+        List<String> currentCollectorsEnabled = Optional.ofNullable(baseEnabled.getCollectors())
+                .orElseGet(ArrayList::new);
+        List<String> currentCollectorsDisabled = Optional.ofNullable(baseDisabled.getCollectors())
+                .orElseGet(ArrayList::new);
+        List<String> requestedCollectorsEnabled = Optional.ofNullable(newEnabled.getCollectors())
+                .orElseGet(ArrayList::new);
+        List<String> requestedCollectorsDisabled = Optional.ofNullable(newDisabled.getCollectors())
+                .orElseGet(ArrayList::new);
+
+        List<String> mergedCollectorsEnabled = combineLists(currentCollectorsEnabled, requestedCollectorsEnabled,
+                requestedCollectorsDisabled);
+        List<String> mergedCollectorsDisabled = combineLists(currentCollectorsDisabled, requestedCollectorsDisabled,
+                requestedCollectorsEnabled);
+
+        merged.getEnable().setCollectors(mergedCollectorsEnabled);
+        merged.getDisable().setCollectors(mergedCollectorsDisabled);
     }
 
     /**

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/http_action/config/PerformanceAnalyzerOverridesClusterConfigAction.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/http_action/config/PerformanceAnalyzerOverridesClusterConfigAction.java
@@ -175,6 +175,12 @@ public class PerformanceAnalyzerOverridesClusterConfigAction extends BaseRestHan
             isValid = Collections.disjoint(requestedOverrides.getEnable().getActions(), requestedOverrides.getDisable().getActions());
         }
 
+        if (isValid
+                && requestedOverrides.getEnable().getCollectors() != null
+                && requestedOverrides.getDisable().getCollectors() != null) {
+            isValid = Collections.disjoint(requestedOverrides.getEnable().getCollectors(), requestedOverrides.getDisable().getCollectors());
+        }
+
         return isValid;
     }
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/MasterServiceMetricsTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/MasterServiceMetricsTests.java
@@ -23,10 +23,8 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSett
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
-
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MasterServiceMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MasterServiceEventMetrics;
 

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/MasterServiceMetricsTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/MasterServiceMetricsTests.java
@@ -22,11 +22,9 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.CustomMetricsLoca
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSettings;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
+
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MasterServiceMetrics;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MasterServiceEventMetrics;
 
 @Ignore
 public class MasterServiceMetricsTests extends CustomMetricsLocationTestBase {

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/MasterServiceMetricsTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/MasterServiceMetricsTests.java
@@ -22,9 +22,13 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.CustomMetricsLoca
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSettings;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MasterServiceMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MasterServiceEventMetrics;
 
 @Ignore
 public class MasterServiceMetricsTests extends CustomMetricsLocationTestBase {

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/ConfigOverridesTestHelper.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/ConfigOverridesTestHelper.java
@@ -36,10 +36,16 @@ public class ConfigOverridesTestHelper {
     public static final String DECIDER2 = "dec2";
     public static final String DECIDER3 = "dec3";
     public static final String DECIDER4 = "dec4";
+    public static final String COLLECTOR1 = "collector1";
+    public static final String COLLECTOR2 = "collector2";
+    public static final String COLLECTOR3 = "collector3";
+    public static final String COLLECTOR4 = "collector4";
     public static final List<String> DISABLED_RCAS_LIST = Arrays.asList(RCA1, RCA2);
     public static final List<String> ENABLED_RCAS_LIST = Arrays.asList(RCA3, RCA4);
     public static final List<String> DISABLED_ACTIONS_LIST = Arrays.asList(ACTION1, ACTION2);
     public static final List<String> ENABLED_DECIDERS_LIST = Arrays.asList(DECIDER3, DECIDER4);
+    public static final List<String> DISABLED_COLLECTORS_LIST = Arrays.asList(COLLECTOR1, COLLECTOR2);
+    public static final List<String> ENABLED_COLLECTORS_LIST = Arrays.asList(COLLECTOR3, COLLECTOR4);
 
     public static ConfigOverrides buildValidConfigOverrides() {
         ConfigOverrides overrides = new ConfigOverrides();
@@ -47,6 +53,8 @@ public class ConfigOverridesTestHelper {
         overrides.getDisable().setActions(DISABLED_ACTIONS_LIST);
         overrides.getEnable().setRcas(ENABLED_RCAS_LIST);
         overrides.getEnable().setDeciders(ENABLED_DECIDERS_LIST);
+        overrides.getEnable().setCollectors(ENABLED_COLLECTORS_LIST);
+        overrides.getDisable().setCollectors(DISABLED_COLLECTORS_LIST);
 
         return overrides;
     }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/setting/handler/ConfigOverridesClusterSettingHandlerTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/config/setting/handler/ConfigOverridesClusterSettingHandlerTests.java
@@ -34,6 +34,10 @@ import java.util.Collections;
 
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.config.ConfigOverridesTestHelper.ACTION1;
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.config.ConfigOverridesTestHelper.ACTION2;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.config.ConfigOverridesTestHelper.COLLECTOR1;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.config.ConfigOverridesTestHelper.COLLECTOR2;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.config.ConfigOverridesTestHelper.COLLECTOR3;
+import static com.amazon.opendistro.elasticsearch.performanceanalyzer.config.ConfigOverridesTestHelper.COLLECTOR4;
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.config.ConfigOverridesTestHelper.DECIDER1;
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.config.ConfigOverridesTestHelper.DECIDER2;
 import static com.amazon.opendistro.elasticsearch.performanceanalyzer.config.ConfigOverridesTestHelper.DECIDER3;
@@ -127,8 +131,14 @@ public class ConfigOverridesClusterSettingHandlerTests {
         additionalOverrides.getDisable().setDeciders(Arrays.asList(DECIDER3, DECIDER1));
         additionalOverrides.getEnable().setDeciders(Collections.singletonList(DECIDER2));
 
+        additionalOverrides.getDisable().setCollectors(Arrays.asList(COLLECTOR3, COLLECTOR1));
+        additionalOverrides.getEnable().setCollectors(Collections.singletonList(COLLECTOR2));
+
         expectedOverrides.getEnable().setDeciders(Arrays.asList(DECIDER2, DECIDER4));
         expectedOverrides.getDisable().setDeciders(Arrays.asList(DECIDER3, DECIDER1));
+
+        expectedOverrides.getEnable().setCollectors(Arrays.asList(COLLECTOR2, COLLECTOR4));
+        expectedOverrides.getDisable().setCollectors(Arrays.asList(COLLECTOR3, COLLECTOR1));
 
         // current enabled actions: none. current disabled actions: 1,2
         additionalOverrides.getEnable().setActions(Arrays.asList(ACTION1, ACTION2));
@@ -154,6 +164,10 @@ public class ConfigOverridesClusterSettingHandlerTests {
         Collections.sort(actual.getEnable().getDeciders());
         assertEquals(expected.getEnable().getDeciders(), actual.getEnable().getDeciders());
 
+        Collections.sort(expected.getEnable().getCollectors());
+        Collections.sort(actual.getEnable().getCollectors());
+        assertEquals(expected.getEnable().getCollectors(), actual.getEnable().getCollectors());
+
         Collections.sort(expected.getDisable().getRcas());
         Collections.sort(actual.getDisable().getRcas());
         assertEquals(expected.getDisable().getRcas(), actual.getDisable().getRcas());
@@ -165,6 +179,10 @@ public class ConfigOverridesClusterSettingHandlerTests {
         Collections.sort(expected.getDisable().getDeciders());
         Collections.sort(actual.getDisable().getDeciders());
         assertEquals(expected.getDisable().getDeciders(), actual.getDisable().getDeciders());
+
+        Collections.sort(expected.getDisable().getCollectors());
+        Collections.sort(actual.getDisable().getCollectors());
+        assertEquals(expected.getDisable().getCollectors(), actual.getDisable().getCollectors());
 
         return true;
     }


### PR DESCRIPTION
*Fixes #, if available:*https://github.com/opendistro-for-elasticsearch/performance-analyzer-rca/issues/487

*Description of changes:*This change is to add support for enabling and disabling collectors through Rest API

```
[root@214d9f4eda93 performanceanalyzer]# curl -X POST "localhost:9200/_opendistro/_performanceanalyzer/override/cluster/config" -H 'Content-Type: application/json' -d'
> {
>   "enable": {
>    },
>   "disable": {
>       "collectors": ["MasterServiceMetrics"]
>    }
> }
> '

{"override triggered":true}[root@214d9f4eda93 performanceanalyzer]#
[root@214d9f4eda93 performanceanalyzer]# curl -X GET "localhost:9200/_opendistro/_performanceanalyzer/override/cluster/config"
{"overrides":"{\"enable\":{\"rcas\":[],\"deciders\":[],\"actions\":[],\"collectors\":[]},\"disable\":{\"rcas\":[],\"deciders\":[],\"actions\":[],\"collectors\":[\"MasterServiceMetrics\"]}}"}
```

Tests
```
1. Current - No collectors in disabled list
Update - Add MasterServiceMetrics in disabled list
Result - MasterServiceMetrics gets disabled

2. Current - MasterServiceMetrics in disabled list
Update - Add MasterServiceMetrics in enabled list
Result - MasterServiceMetrics gets enabled

3. Current - MasterServiceMetrics in enabled list
Update - pass both the lists as empty.
Result - MasterServiceMetrics stays enabled.
When both lists are passed as empty, it retains its former behavior.
```