### PR TITLE
aggregate stale metrics to write_metrics

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/writer/EventLogQueueProcessor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/writer/EventLogQueueProcessor.java
@@ -116,6 +116,7 @@ public class EventLogQueueProcessor {
             } else if (entry.epoch == nextTimeBucket) {
                 nextMetrics.add(entry);
             } else {
+                //increment stale_metrics count when metrics to be collected is falling behind the current bucket
                 PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(
                     WriterMetrics.STALE_METRICS, "", 1);
             }

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/writer/EventLogQueueProcessor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/writer/EventLogQueueProcessor.java
@@ -1,5 +1,7 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.writer;
 
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.WriterMetrics;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CancellationException;
@@ -114,9 +116,8 @@ public class EventLogQueueProcessor {
             } else if (entry.epoch == nextTimeBucket) {
                 nextMetrics.add(entry);
             } else {
-                LOG.info("UNEXPECTED entry ({}) with epoch '{}' arrived" +
-                                " when the current bucket is '{}'",
-                        entry.key, entry.epoch, timeBucket);
+                PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(
+                    WriterMetrics.STALE_METRICS, "", 1);
             }
         }
 


### PR DESCRIPTION
*Fixes #, if available:*

*Description of changes:*
1. Currently when the metrics PA collects arrive late, then it will be logged as info message. Instead we create a new metric STALE_MERIC and aggregate the count.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
