### PR TITLE
Upgrade dom4j to 2.1.3+

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ buildscript {
 plugins {
     id 'java'
     id 'nebula.ospackage' version "8.3.0"
-    id 'com.github.spotbugs' version '4.0.0'
+    id 'com.github.spotbugs' version '4.6.0'
     id 'jacoco'
 }
 


### PR DESCRIPTION
*Fixes #, if available:* https://github.com/opendistro-for-elasticsearch/performance-analyzer/issues/249

*Description of changes:* Upgrade dom4j to 2.1.3+
 Updating the com.github.spotbugs to latest 4.6.0 version, which will bring in 2.1.3 version of dom4j

```
khushbr@3c22fb8556dd performance-analyzer % ./gradlew :dependencyInsight --configuration spotbugs --dependency org.dom4j
=======================================
Elasticsearch Build Hamster says Hello!
  Gradle Version        : 6.6.1
  OS Info               : Mac OS X 10.15.7 (x86_64)
  JDK Version           : 15 (JDK)
  JAVA_HOME             : /Library/Java/JavaVirtualMachines/amazon-corretto-15.jdk/Contents/Home
  Random Testing Seed   : D4919ADDC9EDBED4
  In FIPS 140 mode      : false
=======================================

> Task :dependencyInsight
org.dom4j:dom4j:2.1.3
   variant "runtimeElements" [
      org.gradle.category            = library (not requested)
      org.gradle.dependency.bundling = external (not requested)
      org.gradle.jvm.version         = 8 (not requested)
      org.gradle.libraryelements     = jar (not requested)
      org.gradle.usage               = java-runtime (not requested)
      org.gradle.status              = release (not requested)
   ]

org.dom4j:dom4j:2.1.3
\--- com.github.spotbugs:spotbugs:4.1.1
     \--- spotbugs

A web-based, searchable dependency report is available by adding the --scan option.

Deprecated Gradle features were used in this build, making it incompatible with Gradle 7.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/6.6.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD SUCCESSFUL in 633ms
1 actionable task: 1 executed
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
