### PR TITLE
Fix performance-analyzer-agent-cli plugin path and make executable

### DIFF
--- a/packaging/rpm/postinst
+++ b/packaging/rpm/postinst
@@ -14,8 +14,9 @@ fi
 
 # Prepare the RCA reader process for execution
 cp -r "$ES_HOME"/plugins/opendistro_performance_analyzer/performance-analyzer-rca $ES_HOME
-if [ -f "$ES_HOME"/bin/opendistro_performance_analyzer/performance-analyzer-agent-cli ]; then
-  mv "$ES_HOME"/bin/opendistro_performance_analyzer/performance-analyzer-agent-cli "$ES_HOME"/bin
+if [ -f "$ES_HOME"/plugins/opendistro_performance_analyzer/bin/performance-analyzer-agent-cli ]; then
+  mv "$ES_HOME"/plugins/opendistro_performance_analyzer/bin/performance-analyzer-agent-cli "$ES_HOME"/bin
+  chmod 755 "$ES_HOME"/bin/performance-analyzer-agent-cli
   rm -rf "$ES_HOME"/bin/opendistro_performance_analyzer
 fi
 mkdir -p "$ES_HOME"/data


### PR DESCRIPTION
*Fixes #, if available:*
Fix opendistro-performance-analyzer.service not starting
*Description of changes:*
Changed the path from where the performance-analyzer-agent-cli is moved from and make the file in destination "$ES_HOME"/bin/performance-analyzer-agent-cli executable

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
