### PR TITLE
Revert "Upgrade jackson-databind to 2.12.0 (#259)"

### DIFF
--- a/THIRD-PARTY
+++ b/THIRD-PARTY
@@ -1,6 +1,6 @@
 ** GoogleGuava; version 27.0.1-jre -- https://github.com/google/guava
 ** Jackson-annotations; version 2.8.11 -- https://github.com/FasterXML/jackson-annotations/
-** Jackson-databind; version 2.12.0 -- https://github.com/FasterXML/jackson-databind
+** Jackson-databind; version 2.8.11 -- https://github.com/FasterXML/jackson-databind
 ** jooq; version 3.10.8 -- https://github.com/jOOQ/jOOQ
 ** org.xerial:sqlite-jdbc; version 3.8.11.2 -- https://bitbucket.org/xerial/sqlite-jdbc/src/8de652d3f54cdfd32d5a493130c995f36e16c652/LICENSE?at=default&fileviewer=file-view-default
 ** PowerMock; version 1.6.1 -- https://github.com/powermock/powermock

--- a/build.gradle
+++ b/build.gradle
@@ -211,7 +211,7 @@ dependencies {
     compile 'org.bouncycastle:bcpkix-jdk15on:1.66'
     compile 'com.amazon.opendistro.elasticsearch:performanceanalyzer-rca:1.12'
     compile 'com.fasterxml.jackson.core:jackson-annotations:2.10.4'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-databind', version: '2.12.0'
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.10.4'
     compile 'com.fasterxml.jackson.module:jackson-module-paranamer:2.10.4'
     compile(group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.11.1') {
         force = 'true'


### PR DESCRIPTION
This reverts commit 33e233b1d0d6345703a9dfab0c37cb176f206e5f.

jackson-databind is set back to 2.10.4

*Fixes #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
