### PR TITLE
Change CD workflow to use new staging bucket for artifacts

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -58,6 +58,7 @@ jobs:
           aws-region: us-west-2
 
       - name: Upload Artifacts to S3
+        working-directory: ./tmp/pa
         shell: bash
         run: |
           zip=`ls artifacts/*.zip`

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,9 +1,12 @@
 name: CD
 
 on:
+  # push:
+  #   tags:
+  #     - 'v*'
   push:
-    tags:
-      - 'v*'
+    branches:
+      - " release-workflow-patch"
 
 jobs:
   build:
@@ -50,18 +53,32 @@ jobs:
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-access-key-id: ${{ secrets.AWS_STAGING_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_STAGING_SECRET_ACCESS_KEY }}
           aws-region: us-west-2
 
       - name: Upload Artifacts to S3
-        working-directory: ./tmp/pa
+        shell: bash
         run: |
-          s3_path=s3://artifacts.opendistroforelasticsearch.amazon.com/downloads
-          aws s3 cp artifacts/*.zip $s3_path/elasticsearch-plugins/performance-analyzer/
-          aws s3 cp artifacts/*.rpm $s3_path/rpms/opendistro-performance-analyzer/
-          aws s3 cp artifacts/*.deb $s3_path/debs/opendistro-performance-analyzer/
-          aws cloudfront create-invalidation --distribution-id ${{ secrets.DISTRIBUTION_ID }} --paths "/downloads/*"
+          zip=`ls artifacts/*.zip`
+          rpm=`ls artifacts/*.rpm`
+          deb=`ls artifacts/*.deb`
+
+          # Inject the build number before the suffix
+          zip_outfile=`basename ${zip%.zip}-build-${GITHUB_RUN_NUMBER}.zip`
+          rpm_outfile=`basename ${rpm%.rpm}-build-${GITHUB_RUN_NUMBER}.rpm`
+          deb_outfile=`basename ${deb%.deb}-build-${GITHUB_RUN_NUMBER}.deb`
+
+          s3_prefix="s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshot/elasticsearch-plugins/performance-analyzer/"
+
+          echo "Copying ${zip} to ${s3_prefix}${zip_outfile}"
+          aws s3 cp --quiet $zip ${s3_prefix}${zip_outfile}
+
+          echo "Copying ${rpm} to ${s3_prefix}${rpm_outfile}"
+          aws s3 cp --quiet $rpm ${s3_prefix}${rpm_outfile}
+          
+          echo "Copying ${deb} to ${s3_prefix}${deb_outfile}"
+          aws s3 cp --quiet $deb ${s3_prefix}${deb_outfile}
 
       - name: Upload Workflow Artifacts
         uses: actions/upload-artifact@v1

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -70,7 +70,7 @@ jobs:
           rpm_outfile=`basename ${rpm%.rpm}-build-${GITHUB_RUN_NUMBER}.rpm`
           deb_outfile=`basename ${deb%.deb}-build-${GITHUB_RUN_NUMBER}.deb`
 
-          s3_prefix="s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshot/elasticsearch-plugins/performance-analyzer/"
+          s3_prefix="s3://staging.artifacts.opendistroforelasticsearch.amazon.com/snapshots/elasticsearch-plugins/performance-analyzer/"
 
           echo "Copying ${zip} to ${s3_prefix}${zip_outfile}"
           aws s3 cp --quiet $zip ${s3_prefix}${zip_outfile}

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,12 +1,9 @@
 name: CD
 
 on:
-  # push:
-  #   tags:
-  #     - 'v*'
   push:
-    branches:
-      - "release-workflow-patch"
+    tags:
+      - 'v*'
 
 jobs:
   build:

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -6,7 +6,7 @@ on:
   #     - 'v*'
   push:
     branches:
-      - " release-workflow-patch"
+      - "release-workflow-patch"
 
 jobs:
   build:
@@ -76,7 +76,7 @@ jobs:
 
           echo "Copying ${rpm} to ${s3_prefix}${rpm_outfile}"
           aws s3 cp --quiet $rpm ${s3_prefix}${rpm_outfile}
-          
+
           echo "Copying ${deb} to ${s3_prefix}${deb_outfile}"
           aws s3 cp --quiet $deb ${s3_prefix}${deb_outfile}
 


### PR DESCRIPTION

*Fixes #, if available:*

*Description of changes:*
The infrastructure team is separating the production and staging locations into different AWS accounts. Plugins need to modify their workflows to publish to the new locations.

This PR changes the CD workflow to add a build number and write the zip, deb, and rpm plugin artifacts to staging.artifacts.opendistroforelasticsearch.amazon.com.

Test Result: https://github.com/gaiksaya/performance-analyzer/runs/1684291738?check_suite_focus=true

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
