### PR TITLE
Changed master total PendingQueueSize to PendingQueueSize per task type

### DIFF
--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/MasterServiceMetricsTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/MasterServiceMetricsTests.java
@@ -17,7 +17,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -89,7 +89,7 @@ public class MasterServiceMetricsTests {
     public void testCollectMetrics() {
         masterServiceMetrics.collectMetrics(startTimeInMills);
         String jsonStr = readMetricsInJsonString(1);
-        assertTrue(jsonStr.contains(MasterPendingValue.Constants.PENDING_TASKS_COUNT_VALUE));
+        assertFalse(jsonStr.contains(MasterPendingValue.Constants.PENDING_TASKS_COUNT_VALUE));
     }
 
     @Test
@@ -116,8 +116,8 @@ public class MasterServiceMetricsTests {
         assert metrics.size() == size;
         if (size != 0) {
             String[] jsonStrs = metrics.get(0).value.split("\n");
-            assert jsonStrs.length == 2;
-            return jsonStrs[1];
+            assert jsonStrs.length == 1;
+            return jsonStrs[0];
         } else {
             return null;
         }


### PR DESCRIPTION
Master Pending Queue size per task type

Earlier we were publishing Total number of pending task. For RCA analysis Pending Queue size per task type will give better understanding. Changed total Queue Size to Queue size per task type

*Tests:*

Added some manual entry. Below are the output of manual entry

1. *Output of tmp file*
```
^pending_tasks/current/metadata
{"current_time":1610945977204}
{"Master_PendingQueueSize":5,"Master_PendingTaskType":"create"}
{"Master_PendingQueueSize":3,"Master_PendingTaskType":"delete"}
{"Master_PendingQueueSize":10,"Master_PendingTaskType":"shard-started"}$
```

2. *Table of Master_PendingQueueSize*
```
sqlite> select * from Master_PendingQueueSize;
create-index|5.0|5.0|5.0|5.0
delete-index|3.0|3.0|3.0|3.0
shard-started|10.0|10.0|10.0|10.0
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.