### PR TITLE
Fix jackson cve

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -200,6 +200,11 @@ dependencies {
     configurations.all {
        resolutionStrategy {
           force "com.puppycrawl.tools:checkstyle:${project.checkstyle.toolVersion}"
+          force 'com.fasterxml.jackson.core:jackson-core:2.12.0'
+          force 'com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.12.0'
+          force 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.0'
+          force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.0'
+          force 'junit:junit:4.13.1'
        }
     }
 
@@ -211,9 +216,15 @@ dependencies {
     compile 'org.bouncycastle:bcprov-jdk15on:1.68'
     compile 'org.bouncycastle:bcpkix-jdk15on:1.68'
     compile 'com.amazon.opendistro.elasticsearch:performanceanalyzer-rca:1.12'
-    compile 'com.fasterxml.jackson.core:jackson-annotations:2.10.4'
-    compile 'com.fasterxml.jackson.core:jackson-databind:2.10.4'
-    compile 'com.fasterxml.jackson.module:jackson-module-paranamer:2.10.4'
+    compile('com.fasterxml.jackson.core:jackson-annotations:2.12.0') {
+        force = 'true'
+    }
+    compile('com.fasterxml.jackson.core:jackson-databind:2.12.0') {
+        force = 'true'
+    }
+    compile('com.fasterxml.jackson.module:jackson-module-paranamer:2.12.0') {
+        force = 'true'
+    }
     compile(group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.11.1') {
         force = 'true'
     }
@@ -290,6 +301,10 @@ task cloneGitRepo(type: GitClone) {
 task buildRca() {
     dependsOn(cloneGitRepo)
     doLast {
+        exec {
+            workingDir("$rcaDir")
+            commandLine 'git', 'checkout', 'cve-jackson'
+        }
         exec {
             workingDir("$rcaDir")
             commandLine './gradlew', 'build', '-x', 'test'

--- a/build.gradle
+++ b/build.gradle
@@ -220,7 +220,6 @@ dependencies {
     compile 'com.fasterxml.jackson.core:jackson-annotations:2.10.5'
     compile 'com.fasterxml.jackson.core:jackson-databind:2.10.5.1'
     compile 'com.fasterxml.jackson.module:jackson-module-paranamer:2.10.5'
-    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.10.5'
     compile(group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.11.1') {
         force = 'true'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -225,6 +225,9 @@ dependencies {
     compile('com.fasterxml.jackson.module:jackson-module-paranamer:2.12.0') {
         force = 'true'
     }
+    compile (group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.12.0'){
+        force = 'true'
+    }
     compile(group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.11.1') {
         force = 'true'
     }

--- a/build.gradle
+++ b/build.gradle
@@ -299,10 +299,6 @@ task buildRca() {
     doLast {
         exec {
             workingDir("$rcaDir")
-            commandLine 'git', 'checkout', 'cve-jackson'
-        }
-        exec {
-            workingDir("$rcaDir")
             commandLine './gradlew', 'build', '-x', 'test'
         }
         exec {

--- a/build.gradle
+++ b/build.gradle
@@ -200,10 +200,11 @@ dependencies {
     configurations.all {
        resolutionStrategy {
           force "com.puppycrawl.tools:checkstyle:${project.checkstyle.toolVersion}"
-          force 'com.fasterxml.jackson.core:jackson-core:2.12.0'
-          force 'com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.12.0'
-          force 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.12.0'
-          force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.12.0'
+          force 'com.fasterxml.jackson.core:jackson-databind:2.10.5.1'
+          force 'com.fasterxml.jackson.core:jackson-core:2.10.5'
+          force 'com.fasterxml.jackson.dataformat:jackson-dataformat-smile:2.10.5'
+          force 'com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:2.10.5'
+          force 'com.fasterxml.jackson.dataformat:jackson-dataformat-cbor:2.10.5'
           force 'junit:junit:4.13.1'
        }
     }
@@ -216,18 +217,10 @@ dependencies {
     compile 'org.bouncycastle:bcprov-jdk15on:1.68'
     compile 'org.bouncycastle:bcpkix-jdk15on:1.68'
     compile 'com.amazon.opendistro.elasticsearch:performanceanalyzer-rca:1.12'
-    compile('com.fasterxml.jackson.core:jackson-annotations:2.12.0') {
-        force = 'true'
-    }
-    compile('com.fasterxml.jackson.core:jackson-databind:2.12.0') {
-        force = 'true'
-    }
-    compile('com.fasterxml.jackson.module:jackson-module-paranamer:2.12.0') {
-        force = 'true'
-    }
-    compile (group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.12.0'){
-        force = 'true'
-    }
+    compile 'com.fasterxml.jackson.core:jackson-annotations:2.10.5'
+    compile 'com.fasterxml.jackson.core:jackson-databind:2.10.5.1'
+    compile 'com.fasterxml.jackson.module:jackson-module-paranamer:2.10.5'
+    compile group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.10.5'
     compile(group: 'org.apache.logging.log4j', name: 'log4j-api', version: '2.11.1') {
         force = 'true'
     }


### PR DESCRIPTION
*Fixes #, if available:*

*Description of changes:*

Use jackson version 2.10.5 to fix CVE-2020-25649 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
