### PR TITLE
Added Election Term Metric

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerPlugin.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerPlugin.java
@@ -21,6 +21,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.action.Performanc
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.CacheConfigMetricsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.CircuitBreakerCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.DisksCollector;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.ElectionTermCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.FaultDetectionMetricsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.GCInfoCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.HeapMetricsCollector;
@@ -191,6 +192,7 @@ public final class PerformanceAnalyzerPlugin extends Plugin implements ActionPlu
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new
                 NodeStatsFixedShardsMetricsCollector(performanceAnalyzerController));
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new MasterServiceMetrics());
+        scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new ElectionTermCollector());
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new MasterServiceEventMetrics());
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new DisksCollector());
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new NetworkInterfaceCollector());

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ElectionTermCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ElectionTermCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright <2021> Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ElectionTermCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ElectionTermCollector.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.ESResources;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsProcessor;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.ExceptionsAndErrors;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.WriterMetrics;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+public class ElectionTermCollector extends PerformanceAnalyzerMetricsCollector implements MetricsProcessor {
+    public static final int SAMPLING_TIME_INTERVAL = MetricsConfiguration.CONFIG_MAP.get(ElectionTermCollector.class).samplingInterval;
+    private static final Logger LOG = LogManager.getLogger(ElectionTermCollector.class);
+    private static final int KEYS_PATH_LENGTH = 0;
+    private StringBuilder value;
+
+    public ElectionTermCollector(){
+        super(SAMPLING_TIME_INTERVAL, "ElectionTermCollector");
+        value = new StringBuilder();
+    }
+
+    @Override
+    public String getMetricsPath(long startTime, String... keysPath) {
+        // throw exception if keysPath.length is not equal to 2
+        // (Keys should be Pending_Task_ID, start/finish OR current, metadata)
+        if (keysPath.length != KEYS_PATH_LENGTH) {
+            throw new RuntimeException("keys length should be " + KEYS_PATH_LENGTH);
+        }
+
+        return PerformanceAnalyzerMetrics.generatePath(startTime, PerformanceAnalyzerMetrics.sElectionTermPath);
+    }
+
+    @Override
+    public void collectMetrics(long startTime) {
+        long mCurrT = System.currentTimeMillis();
+        try {
+            if (ESResources.INSTANCE.getClusterService() == null
+                    || ESResources.INSTANCE.getClusterService().state() == null) {
+                return;
+            }
+
+            value.setLength(0);
+            value.append(PerformanceAnalyzerMetrics.getJsonCurrentMilliSeconds())
+                    .append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
+            value.append(new ElectionTermMetrics(
+                    ESResources.INSTANCE.getClusterService().state()
+                            .term()).serialize());
+            saveMetricValues(value.toString(), startTime);
+
+            PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(
+                    WriterMetrics.ELECTION_TERM_COLLECTOR_EXECUTION_TIME, "",
+                    System.currentTimeMillis() - mCurrT);
+
+        } catch (Exception ex) {
+            PerformanceAnalyzerApp.ERRORS_AND_EXCEPTIONS_AGGREGATOR.updateStat(
+                    ExceptionsAndErrors.ELECTION_TERM_COLLECTOR_ERROR, "",
+                    System.currentTimeMillis() - mCurrT);
+            LOG.debug("Exception in Collecting ElectionTerm Metrics: {} for startTime {}",
+                    () -> ex.toString(), () -> startTime);
+        }
+    }
+
+    public static class ElectionTermMetrics extends MetricStatus {
+        private final long electionTerm;
+        public ElectionTermMetrics(long electionTerm) {
+            this.electionTerm = electionTerm;
+        }
+
+        @JsonProperty(AllMetrics.ElectionTermValue.Constants.ELECTION_TERM_VALUE)
+        public long getElectionTerm() {
+            return electionTerm;
+        }
+    }
+}
+

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/util/Utils.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/util/Utils.java
@@ -24,6 +24,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsCo
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.CircuitBreakerCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MasterServiceEventMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MasterServiceMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.ElectionTermCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.NodeDetailsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.NodeStatsAllShardsMetricsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.NodeStatsFixedShardsMetricsCollector;
@@ -54,6 +55,7 @@ public class Utils {
         MetricsConfiguration.CONFIG_MAP.put(NodeStatsFixedShardsMetricsCollector.class, cdefault);
         MetricsConfiguration.CONFIG_MAP.put(MasterServiceEventMetrics.class, new MetricsConfiguration.MetricConfig(1000, 0, 0));
         MetricsConfiguration.CONFIG_MAP.put(MasterServiceMetrics.class, cdefault);
+        MetricsConfiguration.CONFIG_MAP.put(ElectionTermCollector.class, cdefault);
         MetricsConfiguration.CONFIG_MAP.put(FaultDetectionMetricsCollector.class, cdefault);
         MetricsConfiguration.CONFIG_MAP.put(ShardStateCollector.class, cdefault);
         MetricsConfiguration.CONFIG_MAP.put(MasterThrottlingMetricsCollector.class, cdefault);

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ElectionTermCollectorTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ElectionTermCollectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright <2019> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright <2021> Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ElectionTermCollectorTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ElectionTermCollectorTests.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright <2019> Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.ESResources;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PluginSettings;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ElectionTermValue;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.Event;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.util.TestUtil;
+import java.util.List;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.test.ClusterServiceUtils;
+import org.elasticsearch.threadpool.TestThreadPool;
+import org.elasticsearch.threadpool.ThreadPool;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+public class ElectionTermCollectorTests {
+    private ElectionTermCollector electionTermCollector;
+    private long startTimeInMills = 1153721339;
+    private ThreadPool threadPool;
+
+    @Mock
+    private ClusterService mockedClusterService;
+
+    @Before
+    public void init() {
+        initMocks(this);
+        System.setProperty("performanceanalyzer.metrics.log.enabled", "False");
+        threadPool = new TestThreadPool("test");
+        ClusterService clusterService = ClusterServiceUtils.createClusterService(threadPool);
+        ESResources.INSTANCE.setClusterService(clusterService);
+
+        MetricsConfiguration.CONFIG_MAP.put(ElectionTermCollector.class, MetricsConfiguration.cdefault);
+        electionTermCollector = new ElectionTermCollector();
+
+        //clean metricQueue before running every test
+        TestUtil.readEvents();
+    }
+
+    @After
+    public void tearDown() {
+        threadPool.shutdownNow();
+    }
+
+    @Test
+    public void testGetMetricPath() {
+        String expectedPath = PluginSettings.instance().getMetricsLocation()
+                + PerformanceAnalyzerMetrics.getTimeInterval(startTimeInMills) + "/"
+                + PerformanceAnalyzerMetrics.sElectionTermPath;
+        String actualPath = electionTermCollector.getMetricsPath(startTimeInMills);
+        assertEquals(expectedPath,actualPath);
+
+        try {
+            electionTermCollector.getMetricsPath(startTimeInMills,"current");
+            fail("Negative scenario test: Should have been a RuntimeException");
+        } catch (RuntimeException ex){
+            //- expecting exception...1 value passed; 0 expected
+        }
+    }
+
+    @Test
+    public void testCollectMetrics() {
+        electionTermCollector.collectMetrics(startTimeInMills);
+        String jsonStr = readMetricsInJsonString(1);
+        assertTrue(jsonStr.contains(ElectionTermValue.Constants.ELECTION_TERM_VALUE));
+
+    }
+
+    @Test
+    public void testWithMockClusterService() {
+        ESResources.INSTANCE.setClusterService(mockedClusterService);
+        electionTermCollector.collectMetrics(startTimeInMills);
+        String jsonStr = readMetricsInJsonString(0);
+        assertNull(jsonStr);
+
+        ESResources.INSTANCE.setClusterService(mockedClusterService);
+        when(mockedClusterService.getMasterService()).thenThrow(new RuntimeException());
+        electionTermCollector.collectMetrics(startTimeInMills);
+        jsonStr = readMetricsInJsonString(0);
+        assertNull(jsonStr);
+
+        ESResources.INSTANCE.setClusterService(null);
+        electionTermCollector.collectMetrics(startTimeInMills);
+        jsonStr = readMetricsInJsonString(0);
+        assertNull(jsonStr);
+    }
+
+    private String readMetricsInJsonString(int size) {
+        List<Event> metrics = TestUtil.readEvents();
+        assert metrics.size() == size;
+        if (size != 0) {
+            String[] jsonStrs = metrics.get(0).value.split("\n");
+            assert jsonStrs.length == 2;
+            return jsonStrs[1];
+        } else {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
This Metric will Publish the Only Election term number

*Tests:*
Docker Container Testing

*1. Output of tmp file*
```
^election_term
{"current_time":1612872530595}
{"Election_Term":18}$
```
*2. Entry in Election term table*
```
sqlite> select * from Election_Term;
18.0|18.0|18.0|18.0
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
