### PR TITLE
Increase the max heap limit to check against in the integ tests

### DIFF
--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/integ_test/HeapMetricsIT.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/integ_test/HeapMetricsIT.java
@@ -21,7 +21,7 @@ public class HeapMetricsIT  extends MetricCollectorIntegTestBase {
 
     private static final Logger LOG = LogManager.getLogger(HeapMetricsIT.class);
     private double MIN_HEAP = 50 * 1024 * 1024 ; // 50 MB
-    private double MAX_HEAP = 512 * 1024 * 1024 ; // 512 MB
+    private double MAX_HEAP = 2 * 1024 * 1024 * 1024 ; // 2 GB
     @Before
     public void init() throws Exception {
         initNodes();


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/opendistro-build/issues/339

*Description of changes:*
Currently we expect the max heap to be within 512MB, however, for our integration tests hooked up with the infra team, the max heap size is 1GB. This causes the heap metrics integ test to fail.

This change increases the max limit to check against to 2GB from 512MB.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
