### PR TITLE
Changes to collect shard indexing pressure metrics and push to shared location

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerPlugin.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerPlugin.java
@@ -208,7 +208,7 @@ public final class PerformanceAnalyzerPlugin extends Plugin implements ActionPlu
             scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new ShardIndexingPressureMetricsCollector(
                 performanceAnalyzerController,configOverridesWrapper));
         } catch (ClassNotFoundException e) {
-            LOG.debug("Shard IndexingPressure not present in this ES version. Skipping ShardIndexingPressureMetricsCollector");
+            LOG.info("Shard IndexingPressure not present in this ES version. Skipping ShardIndexingPressureMetricsCollector");
         }
         scheduledMetricCollectorsExecutor.start();
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerPlugin.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerPlugin.java
@@ -24,6 +24,7 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.DisksC
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.FaultDetectionMetricsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.GCInfoCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.HeapMetricsCollector;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.ShardIndexingPressureMetricsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MasterServiceEventMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MasterServiceMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MasterThrottlingMetricsCollector;
@@ -201,6 +202,8 @@ public final class PerformanceAnalyzerPlugin extends Plugin implements ActionPlu
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new ShardStateCollector(
                 performanceAnalyzerController,configOverridesWrapper));
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new MasterThrottlingMetricsCollector(
+                performanceAnalyzerController,configOverridesWrapper));
+        scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new ShardIndexingPressureMetricsCollector(
                 performanceAnalyzerController,configOverridesWrapper));
         scheduledMetricCollectorsExecutor.start();
 

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerPlugin.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerPlugin.java
@@ -203,8 +203,13 @@ public final class PerformanceAnalyzerPlugin extends Plugin implements ActionPlu
                 performanceAnalyzerController,configOverridesWrapper));
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new MasterThrottlingMetricsCollector(
                 performanceAnalyzerController,configOverridesWrapper));
-        scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new ShardIndexingPressureMetricsCollector(
+        try {
+            Class.forName(ShardIndexingPressureMetricsCollector.SHARD_INDEXING_PRESSURE_CLASS_NAME);
+            scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new ShardIndexingPressureMetricsCollector(
                 performanceAnalyzerController,configOverridesWrapper));
+        } catch (ClassNotFoundException e) {
+            LOG.debug("Shard IndexingPressure not present in this ES version. Skipping ShardIndexingPressureMetricsCollector");
+        }
         scheduledMetricCollectorsExecutor.start();
 
         EventLog eventLog = new EventLog();

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardIndexingPressureMetricsCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardIndexingPressureMetricsCollector.java
@@ -100,27 +100,24 @@ public class ShardIndexingPressureMetricsCollector extends PerformanceAnalyzerMe
                             JSONObject shardId = (JSONObject) parser.parse(mapper.writeValueAsString(tracker.get("shardId")));
                             value.append(PerformanceAnalyzerMetrics.getJsonCurrentMilliSeconds())
                                 .append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
-                            value.append(new ShardIndexingPressureStatus(AllMetrics.ShardIndexingPressureNodeRoleType.COORDINATING.toString(),
+                            value.append(new ShardIndexingPressureStatus(AllMetrics.IndexingStage.COORDINATING.toString(),
                                 shardId.get("indexName").toString(), shardId.get("id").toString(),
-                                true,
                                 Long.parseLong(tracker.get("coordinatingRejections").toString()),
                                 Long.parseLong(tracker.get("currentCoordinatingBytes").toString()),
                                 Long.parseLong(tracker.get("primaryAndCoordinatingLimits").toString()),
                                 Double.longBitsToDouble(Long.parseLong(tracker.get("coordinatingThroughputMovingAverage").toString())),
                                 Long.parseLong(tracker.get("lastSuccessfulCoordinatingRequestTimestamp").toString())).serialize())
                                 .append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
-                            value.append(new ShardIndexingPressureStatus(AllMetrics.ShardIndexingPressureNodeRoleType.PRIMARY.toString(),
+                            value.append(new ShardIndexingPressureStatus(AllMetrics.IndexingStage.PRIMARY.toString(),
                                 shardId.get("indexName").toString(), shardId.get("id").toString(),
-                                true,
                                 Long.parseLong(tracker.get("primaryRejections").toString()),
                                 Long.parseLong(tracker.get("currentPrimaryBytes").toString()),
                                 Long.parseLong(tracker.get("primaryAndCoordinatingLimits").toString()),
                                 Double.longBitsToDouble(Long.parseLong(tracker.get("primaryThroughputMovingAverage").toString())),
                                 Long.parseLong(tracker.get("lastSuccessfulPrimaryRequestTimestamp").toString())).serialize())
                                 .append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
-                            value.append(new ShardIndexingPressureStatus(AllMetrics.ShardIndexingPressureNodeRoleType.REPLICA.toString(),
+                            value.append(new ShardIndexingPressureStatus(AllMetrics.IndexingStage.REPLICA.toString(),
                                 shardId.get("indexName").toString(), shardId.get("id").toString(),
-                                true,
                                 Long.parseLong(tracker.get("replicaRejections").toString()),
                                 Long.parseLong(tracker.get("currentReplicaBytes").toString()),
                                 Long.parseLong(tracker.get("replicaLimits").toString()),
@@ -157,7 +154,7 @@ public class ShardIndexingPressureMetricsCollector extends PerformanceAnalyzerMe
     }
 
     static class ShardIndexingPressureStatus extends MetricStatus {
-        private final String nodeRole;
+        private final String indexingStage;
         private final String indexName;
         private final String shardId;
         private final long rejectionCount;
@@ -166,9 +163,9 @@ public class ShardIndexingPressureMetricsCollector extends PerformanceAnalyzerMe
         private final double averageWindowThroughput;
         private final long lastSuccessfulTimestamp;
 
-        public ShardIndexingPressureStatus(String nodeRole, String indexName, String shardId, boolean isActiveShard, long rejectionCount, long currentBytes,
+        public ShardIndexingPressureStatus(String indexingStage, String indexName, String shardId, long rejectionCount, long currentBytes,
                                            long currentLimits, double averageWindowThroughput, long lastSuccessfulTimestamp) {
-            this.nodeRole = nodeRole;
+            this.indexingStage = indexingStage;
             this.indexName = indexName;
             this.shardId = shardId;
             this.rejectionCount = rejectionCount;
@@ -178,9 +175,9 @@ public class ShardIndexingPressureMetricsCollector extends PerformanceAnalyzerMe
             this.lastSuccessfulTimestamp = lastSuccessfulTimestamp;
         }
 
-        @JsonProperty(ShardIndexingPressureDimension.Constants.NODE_ROLE_VALUE)
-        public String getNodeRole() {
-            return nodeRole;
+        @JsonProperty(ShardIndexingPressureDimension.Constants.INDEXING_STAGE)
+        public String getIndexingStage() {
+            return indexingStage;
         }
 
         @JsonProperty(ShardIndexingPressureDimension.Constants.INDEX_NAME_VALUE)

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardIndexingPressureMetricsCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardIndexingPressureMetricsCollector.java
@@ -1,0 +1,280 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.ESResources;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PerformanceAnalyzerController;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.overrides.ConfigOverridesWrapper;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ShardIndexingPressureDimension;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.ShardIndexingPressureValue;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsProcessor;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.elasticsearch.index.IndexingPressure;
+import org.jooq.tools.json.JSONObject;
+import org.jooq.tools.json.JSONParser;
+import org.jooq.tools.json.ParseException;
+
+import java.lang.reflect.Field;
+import java.util.Map;
+
+public class ShardIndexingPressureMetricsCollector extends PerformanceAnalyzerMetricsCollector implements MetricsProcessor {
+    public static final int SAMPLING_TIME_INTERVAL = MetricsConfiguration
+        .CONFIG_MAP.get(ShardIndexingPressureMetricsCollector.class).samplingInterval;
+    private static final int KEYS_PATH_LENGTH = 0;
+    private static final Logger LOG = LogManager.getLogger(ShardIndexingPressureMetricsCollector.class);
+    private static final ObjectMapper mapper = new ObjectMapper();
+    private static final JSONParser parser = new JSONParser();
+
+    //Class And Field Names
+    public static final String SHARD_INDEXING_PRESSURE_CLASS_NAME = "org.elasticsearch.index.ShardIndexingPressure";
+    public static final String CLUSTER_SERVICE_CLASS_NAME = "org.elasticsearch.cluster.service.ClusterService";
+    public static final String INDEXING_PRESSURE_CLASS_NAME = "org.elasticsearch.index.IndexingPressure";
+    public static final String SHARD_INDEXING_PRESSURE_STORE_CLASS_NAME = "org.elasticsearch.index.ShardIndexingPressureStore";
+    public static final String INDEXING_PRESSURE_FIELD_NAME = "indexingPressure";
+    public static final String SHARD_INDEXING_PRESSURE_FIELD_NAME = "shardIndexingPressure";
+    public static final String SHARD_INDEXING_PRESSURE_STORE_FIELD_NAME = "shardIndexingPressureStore";
+    public static final String SHARD_INDEXING_PRESSURE_HOT_STORE_FIELD_NAME = "shardIndexingPressureHotStore";
+    public static final String SHARD_INDEXING_PRESSURE_COLD_STORE_FIELD_NAME = "shardIndexingPressureColdStore";
+
+    private final ConfigOverridesWrapper configOverridesWrapper;
+    private final PerformanceAnalyzerController controller;
+    private StringBuilder value;
+
+    public ShardIndexingPressureMetricsCollector(PerformanceAnalyzerController controller,
+                                                 ConfigOverridesWrapper configOverridesWrapper) {
+        super(SAMPLING_TIME_INTERVAL, "ShardIndexingPressureMetricsCollector");
+        value = new StringBuilder();
+        this.configOverridesWrapper = configOverridesWrapper;
+        this.controller = controller;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void collectMetrics(long startTime) {
+        if(!controller.isCollectorEnabled(configOverridesWrapper, getCollectorName())) {
+            return;
+        }
+
+        try {
+            Class.forName(SHARD_INDEXING_PRESSURE_CLASS_NAME);
+        } catch (ClassNotFoundException e) {
+            LOG.debug("Shard IndexingPressure not present in this ES version. Skipping ShardIndexingPressureMetricsCollector");
+            return;
+        }
+
+        try {
+            ClusterService clusterService = ESResources.INSTANCE.getClusterService();
+            if (clusterService != null) {
+                IndexingPressure indexingPressure = (IndexingPressure) getField(CLUSTER_SERVICE_CLASS_NAME, INDEXING_PRESSURE_FIELD_NAME).get(clusterService);
+                if(indexingPressure != null) {
+                    Object shardIndexingPressure = getField(INDEXING_PRESSURE_CLASS_NAME, SHARD_INDEXING_PRESSURE_FIELD_NAME).get(indexingPressure);
+                    Object shardIndexingPressureStore = getField(SHARD_INDEXING_PRESSURE_CLASS_NAME, SHARD_INDEXING_PRESSURE_STORE_FIELD_NAME).get(shardIndexingPressure);
+                    Map<Long, Object> shardIndexingPressureHotStore =
+                        (Map<Long, Object>) getField(SHARD_INDEXING_PRESSURE_STORE_CLASS_NAME, SHARD_INDEXING_PRESSURE_HOT_STORE_FIELD_NAME)
+                            .get(shardIndexingPressureStore);
+                    Map<Long, Object> shardIndexingPressureColdStore =
+                        (Map<Long, Object>) getField(SHARD_INDEXING_PRESSURE_STORE_CLASS_NAME, SHARD_INDEXING_PRESSURE_COLD_STORE_FIELD_NAME)
+                            .get(shardIndexingPressureStore);
+
+                    value.setLength(0);
+                    /*
+                    The shard metrics are written in the shared location along with the isActiveShard flag which
+                    determines if the shard had active writes or not. Will add all the shard metrics from the hot store.
+                     */
+                    shardIndexingPressureHotStore.entrySet().stream().forEach(storeObject -> {
+                        try {
+                            JSONObject tracker = (JSONObject) parser.parse(mapper.writeValueAsString(storeObject.getValue()));
+                            JSONObject shardId = (JSONObject) parser.parse(mapper.writeValueAsString(tracker.get("shardId")));
+                            value.append(PerformanceAnalyzerMetrics.getJsonCurrentMilliSeconds())
+                                .append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
+                            value.append(new ShardIndexingPressureStatus(AllMetrics.ShardIndexingPressureNodeRoleType.COORDINATING.toString(),
+                                shardId.get("indexName").toString(), shardId.get("id").toString(),
+                                true,
+                                Long.parseLong(tracker.get("coordinatingRejections").toString()),
+                                Long.parseLong(tracker.get("currentCoordinatingBytes").toString()),
+                                Long.parseLong(tracker.get("primaryAndCoordinatingLimits").toString()),
+                                Double.longBitsToDouble(Long.parseLong(tracker.get("coordinatingThroughputMovingAverage").toString())),
+                                Long.parseLong(tracker.get("lastSuccessfulCoordinatingRequestTimestamp").toString())).serialize())
+                                .append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
+                            value.append(new ShardIndexingPressureStatus(AllMetrics.ShardIndexingPressureNodeRoleType.PRIMARY.toString(),
+                                shardId.get("indexName").toString(), shardId.get("id").toString(),
+                                true,
+                                Long.parseLong(tracker.get("primaryRejections").toString()),
+                                Long.parseLong(tracker.get("currentPrimaryBytes").toString()),
+                                Long.parseLong(tracker.get("primaryAndCoordinatingLimits").toString()),
+                                Double.longBitsToDouble(Long.parseLong(tracker.get("primaryThroughputMovingAverage").toString())),
+                                Long.parseLong(tracker.get("lastSuccessfulPrimaryRequestTimestamp").toString())).serialize())
+                                .append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
+                            value.append(new ShardIndexingPressureStatus(AllMetrics.ShardIndexingPressureNodeRoleType.REPLICA.toString(),
+                                shardId.get("indexName").toString(), shardId.get("id").toString(),
+                                true,
+                                Long.parseLong(tracker.get("replicaRejections").toString()),
+                                Long.parseLong(tracker.get("currentReplicaBytes").toString()),
+                                Long.parseLong(tracker.get("replicaLimits").toString()),
+                                Double.longBitsToDouble(Long.parseLong(tracker.get("replicaThroughputMovingAverage").toString())),
+                                Long.parseLong(tracker.get("lastSuccessfulReplicaRequestTimestamp").toString())).serialize())
+                                .append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
+                        } catch (JsonProcessingException | ParseException e) {
+                            LOG.debug("Exception raised while parsing string to json object. Skipping IndexingPressureMetricsCollector");
+                        }
+                    });
+
+                    /*
+                    Once all the metrics is added from the hot store we will skip the shard details from cold store that
+                    were present in hot store to publish relevant metrics for the rest of the shards.
+                     */
+                    shardIndexingPressureColdStore.entrySet().stream()
+                        .filter(storeObject -> !shardIndexingPressureHotStore.containsKey(storeObject.getKey()))
+                        .forEach(storeObject -> {
+                            try {
+                                JSONObject tracker = (JSONObject) parser.parse(mapper.writeValueAsString(storeObject.getValue()));
+                                JSONObject shardId = (JSONObject) parser.parse(mapper.writeValueAsString(tracker.get("shardId")));
+                                value.append(PerformanceAnalyzerMetrics.getJsonCurrentMilliSeconds())
+                                    .append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
+                                value.append(new ShardIndexingPressureStatus(AllMetrics.ShardIndexingPressureNodeRoleType.COORDINATING.toString(),
+                                    shardId.get("indexName").toString(), shardId.get("id").toString(),
+                                    false,
+                                    Long.parseLong(tracker.get("coordinatingRejections").toString()),
+                                    Long.parseLong(tracker.get("currentCoordinatingBytes").toString()),
+                                    Long.parseLong(tracker.get("primaryAndCoordinatingLimits").toString()),
+                                    Double.longBitsToDouble(Long.parseLong(tracker.get("coordinatingThroughputMovingAverage").toString())),
+                                    Long.parseLong(tracker.get("lastSuccessfulCoordinatingRequestTimestamp").toString())).serialize())
+                                    .append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
+                                value.append(new ShardIndexingPressureStatus(AllMetrics.ShardIndexingPressureNodeRoleType.PRIMARY.toString(),
+                                    shardId.get("indexName").toString(), shardId.get("id").toString(),
+                                    false,
+                                    Long.parseLong(tracker.get("primaryRejections").toString()),
+                                    Long.parseLong(tracker.get("currentPrimaryBytes").toString()),
+                                    Long.parseLong(tracker.get("primaryAndCoordinatingLimits").toString()),
+                                    Double.longBitsToDouble(Long.parseLong(tracker.get("primaryThroughputMovingAverage").toString())),
+                                    Long.parseLong(tracker.get("lastSuccessfulPrimaryRequestTimestamp").toString())).serialize())
+                                    .append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
+                                value.append(new ShardIndexingPressureStatus(AllMetrics.ShardIndexingPressureNodeRoleType.REPLICA.toString(),
+                                    shardId.get("indexName").toString(), shardId.get("id").toString(),
+                                    false,
+                                    Long.parseLong(tracker.get("replicaRejections").toString()),
+                                    Long.parseLong(tracker.get("currentReplicaBytes").toString()),
+                                    Long.parseLong(tracker.get("replicaLimits").toString()),
+                                    Double.longBitsToDouble(Long.parseLong(tracker.get("replicaThroughputMovingAverage").toString())),
+                                    Long.parseLong(tracker.get("lastSuccessfulReplicaRequestTimestamp").toString())).serialize())
+                                    .append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
+                            } catch (JsonProcessingException | ParseException e) {
+                                LOG.debug("Exception raised while parsing string to json object. Skipping IndexingPressureMetricsCollector");
+                            }
+                        });
+                }
+            }
+        } catch (NoSuchFieldException | IllegalAccessException | ClassNotFoundException e) {
+            LOG.debug("Exception raised. Skipping IndexingPressureMetricsCollector");
+        }
+
+        saveMetricValues(value.toString(), startTime);
+    }
+
+    Field getField(String className, String fieldName) throws NoSuchFieldException, ClassNotFoundException {
+        Class<?> clusterServiceClass = Class.forName(className);
+        Field indexingPressureField = clusterServiceClass.getDeclaredField(fieldName);
+        indexingPressureField.setAccessible(true);
+        return indexingPressureField;
+    }
+
+    @Override
+    public String getMetricsPath(long startTime, String... keysPath) {
+        if (keysPath.length != KEYS_PATH_LENGTH) {
+            throw new RuntimeException("keys length should be " + KEYS_PATH_LENGTH);
+        }
+
+        return PerformanceAnalyzerMetrics.generatePath(startTime, PerformanceAnalyzerMetrics.sShardIndexingPressurePath);
+    }
+
+    static class ShardIndexingPressureStatus extends MetricStatus {
+        private final String nodeRole;
+        private final String indexName;
+        private final String shardId;
+        private final boolean isActiveShard;
+        private final long rejectionCount;
+        private final long currentBytes;
+        private final long currentLimits;
+        private final double averageWindowThroughput;
+        private final long lastSuccessfulTimestamp;
+
+        public ShardIndexingPressureStatus(String nodeRole, String indexName, String shardId, boolean isActiveShard, long rejectionCount, long currentBytes,
+                                           long currentLimits, double averageWindowThroughput, long lastSuccessfulTimestamp) {
+            this.nodeRole = nodeRole;
+            this.indexName = indexName;
+            this.shardId = shardId;
+            this.isActiveShard = isActiveShard;
+            this.rejectionCount = rejectionCount;
+            this.currentBytes = currentBytes;
+            this.currentLimits = currentLimits;
+            this.averageWindowThroughput = averageWindowThroughput;
+            this.lastSuccessfulTimestamp = lastSuccessfulTimestamp;
+        }
+
+        @JsonProperty(ShardIndexingPressureDimension.Constants.NODE_ROLE_VALUE)
+        public String getNodeRole() {
+            return nodeRole;
+        }
+
+        @JsonProperty(ShardIndexingPressureDimension.Constants.INDEX_NAME_VALUE)
+        public String getIndexName() {
+            return indexName;
+        }
+
+        @JsonProperty(ShardIndexingPressureDimension.Constants.SHARD_ID_VALUE)
+        public String getShardId() {
+            return shardId;
+        }
+
+        @JsonProperty(ShardIndexingPressureValue.Constants.IS_ACTIVE_SHARD)
+        public Boolean getIsActiveShard() {
+            return isActiveShard;
+        }
+
+        @JsonProperty(ShardIndexingPressureValue.Constants.REJECTION_COUNT_VALUE)
+        public long getRejectionCount() {
+            return rejectionCount;
+        }
+
+        @JsonProperty(ShardIndexingPressureValue.Constants.CURRENT_BYTES)
+        public long getCurrentBytes() {
+            return rejectionCount;
+        }
+
+        @JsonProperty(ShardIndexingPressureValue.Constants.CURRENT_LIMITS)
+        public long getCurrentLimits() {
+            return currentLimits;
+        }
+
+        @JsonProperty(ShardIndexingPressureValue.Constants.AVERAGE_WINDOW_THROUGHPUT)
+        public double getAverageWindowThroughput() {
+            return averageWindowThroughput;
+        }
+
+        @JsonProperty(ShardIndexingPressureValue.Constants.LAST_SUCCESSFUL_TIMESTAMP)
+        public long getLastSuccessfulTimestamp() {
+            return lastSuccessfulTimestamp;
+        }
+    }
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardIndexingPressureMetricsCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardIndexingPressureMetricsCollector.java
@@ -46,7 +46,6 @@ public class ShardIndexingPressureMetricsCollector extends PerformanceAnalyzerMe
     private static final ObjectMapper mapper = new ObjectMapper();
     private static final JSONParser parser = new JSONParser();
 
-    //Class And Field Names
     public static final String SHARD_INDEXING_PRESSURE_CLASS_NAME = "org.elasticsearch.index.ShardIndexingPressure";
     public static final String CLUSTER_SERVICE_CLASS_NAME = "org.elasticsearch.cluster.service.ClusterService";
     public static final String INDEXING_PRESSURE_CLASS_NAME = "org.elasticsearch.index.IndexingPressure";

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardIndexingPressureMetricsCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardIndexingPressureMetricsCollector.java
@@ -76,13 +76,6 @@ public class ShardIndexingPressureMetricsCollector extends PerformanceAnalyzerMe
         }
 
         try {
-            Class.forName(SHARD_INDEXING_PRESSURE_CLASS_NAME);
-        } catch (ClassNotFoundException e) {
-            LOG.debug("Shard IndexingPressure not present in this ES version. Skipping ShardIndexingPressureMetricsCollector");
-            return;
-        }
-
-        try {
             ClusterService clusterService = ESResources.INSTANCE.getClusterService();
             if (clusterService != null) {
                 IndexingPressure indexingPressure = (IndexingPressure) getField(CLUSTER_SERVICE_CLASS_NAME, INDEXING_PRESSURE_FIELD_NAME).get(clusterService);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/util/Utils.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/util/Utils.java
@@ -18,6 +18,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer.util;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.ESResources;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.CacheConfigMetricsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.FaultDetectionMetricsCollector;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.ShardIndexingPressureMetricsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.MasterThrottlingMetricsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.ShardStateCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
@@ -57,6 +58,7 @@ public class Utils {
         MetricsConfiguration.CONFIG_MAP.put(FaultDetectionMetricsCollector.class, cdefault);
         MetricsConfiguration.CONFIG_MAP.put(ShardStateCollector.class, cdefault);
         MetricsConfiguration.CONFIG_MAP.put(MasterThrottlingMetricsCollector.class, cdefault);
+        MetricsConfiguration.CONFIG_MAP.put(ShardIndexingPressureMetricsCollector.class, cdefault);
     }
 
     // These methods are utility functions for the Node Stat Metrics Collectors. These methods are used by both the all

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardIndexingPressureMetricsCollectorTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardIndexingPressureMetricsCollectorTests.java
@@ -1,0 +1,82 @@
+/*
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.CustomMetricsLocationTestBase;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.ESResources;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PerformanceAnalyzerController;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.overrides.ConfigOverridesWrapper;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.Event;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.util.TestUtil;
+import org.elasticsearch.cluster.service.ClusterService;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+@PrepareForTest(Class.class)
+public class ShardIndexingPressureMetricsCollectorTests extends CustomMetricsLocationTestBase {
+
+    private ShardIndexingPressureMetricsCollector shardIndexingPressureMetricsCollector;
+
+    @Mock
+    private ClusterService mockClusterService;
+
+    @Mock
+    PerformanceAnalyzerController mockController;
+
+    @Mock
+    ConfigOverridesWrapper mockConfigOverrides;
+
+    @Before
+    public void init() {
+        initMocks(this);
+        ESResources.INSTANCE.setClusterService(mockClusterService);
+        System.setProperty("performanceanalyzer.metrics.log.enabled", "False");
+        MetricsConfiguration.CONFIG_MAP.put(ShardIndexingPressureMetricsCollector.class, MetricsConfiguration.cdefault);
+        shardIndexingPressureMetricsCollector = new ShardIndexingPressureMetricsCollector(mockController, mockConfigOverrides);
+
+        //clean metricQueue before running every test
+        TestUtil.readEvents();
+    }
+
+    @Test
+    public void testShardIndexingPressureMetrics() {
+        long startTimeInMills = 1153721339;
+        Mockito.when(mockController.isCollectorEnabled(mockConfigOverrides, "ShardIndexingPressureMetricsCollector"))
+            .thenReturn(true);
+        shardIndexingPressureMetricsCollector.saveMetricValues("shard_indexing_pressure_metrics", startTimeInMills);
+
+        List<Event> metrics = TestUtil.readEvents();
+        assertEquals(1, metrics.size());
+        assertEquals("shard_indexing_pressure_metrics", metrics.get(0).value);
+
+        try {
+            shardIndexingPressureMetricsCollector.saveMetricValues("shard_indexing_pressure_metrics", startTimeInMills, "123");
+            assertTrue("Negative scenario test: Should have been a RuntimeException", true);
+        } catch (RuntimeException ex) {
+            //- expecting exception...1 values passed; 0 expected
+        }
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* [perf-analyzer-rca/561](https://github.com/opendistro-for-elasticsearch/performance-analyzer-rca/issues/561)

*Description of changes:*
Code changes to add a new collector.
Below are the metrics that will be collected.
1. rejectionCount - Keeps track of the rejection count.
2. currentBytes - Keeps track of the inflight request size.
3. currentLimits - Keeps track of the shard limits(logic internal to AES).
4. averageWindowThroughput - Keeps track of the average throughput of last N requests.
5. lastSuccessfulTimestamp - Keeps track of the timestamp of last successful request.

These metrics are published with following dimensions -
1. indexingStage - Coordinating, Primary or replica.
2. indexName - Name of the index.
3. shardId - Id of the shard.

