### PR TITLE
Adding a additional check to just process first 50 objects of hot store

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardIndexingPressureMetricsCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardIndexingPressureMetricsCollector.java
@@ -55,6 +55,8 @@ public class ShardIndexingPressureMetricsCollector extends PerformanceAnalyzerMe
     public static final String SHARD_INDEXING_PRESSURE_STORE_FIELD_NAME = "shardIndexingPressureStore";
     public static final String SHARD_INDEXING_PRESSURE_HOT_STORE_FIELD_NAME = "shardIndexingPressureHotStore";
 
+    private static final Integer MAX_HOT_STORE_LIMIT = 50;
+
     private final ConfigOverridesWrapper configOverridesWrapper;
     private final PerformanceAnalyzerController controller;
     private StringBuilder value;
@@ -86,7 +88,7 @@ public class ShardIndexingPressureMetricsCollector extends PerformanceAnalyzerMe
                             .get(shardIndexingPressureStore);
 
                     value.setLength(0);
-                    shardIndexingPressureHotStore.entrySet().stream().forEach(storeObject -> {
+                    shardIndexingPressureHotStore.entrySet().stream().limit(MAX_HOT_STORE_LIMIT).forEach(storeObject -> {
                         try {
                             JSONObject tracker = (JSONObject) parser.parse(mapper.writeValueAsString(storeObject.getValue()));
                             JSONObject shardId = (JSONObject) parser.parse(mapper.writeValueAsString(tracker.get("shardId")));


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/performance-analyzer/issues/283

*Description of changes:*
Added a check to just process first 50 objects of hot store. This is a safe guarding mechanism to avoid processing of n items in the hot store and eventually leading to degraded performance of rca agent.

*Testing*
 https://ideone.com/l9HsoH

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
