### PR TITLE
[Bug Fix] Incorrect metric value was returned from the getter of curr…

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardIndexingPressureMetricsCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/ShardIndexingPressureMetricsCollector.java
@@ -202,7 +202,7 @@ public class ShardIndexingPressureMetricsCollector extends PerformanceAnalyzerMe
 
         @JsonProperty(ShardIndexingPressureValue.Constants.CURRENT_BYTES)
         public long getCurrentBytes() {
-            return rejectionCount;
+            return currentBytes;
         }
 
         @JsonProperty(ShardIndexingPressureValue.Constants.CURRENT_LIMITS)


### PR DESCRIPTION
…ent bytes

*Issue #, if available:*  https://github.com/opendistro-for-elasticsearch/performance-analyzer/issues/286

*Description of changes:*
The getter method was returning rejectionCount instead of currentBytes. Hence updated the code to return the appropriate value from the getters.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
