### PR TITLE
Track admission control metrics

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerPlugin.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/PerformanceAnalyzerPlugin.java
@@ -18,6 +18,7 @@ package com.amazon.opendistro.elasticsearch.performanceanalyzer;
 import static java.util.Collections.singletonList;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.action.PerformanceAnalyzerActionFilter;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.AdmissionControlMetricsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.CacheConfigMetricsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.CircuitBreakerCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.DisksCollector;
@@ -203,6 +204,7 @@ public final class PerformanceAnalyzerPlugin extends Plugin implements ActionPlu
                 performanceAnalyzerController,configOverridesWrapper));
         scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new MasterThrottlingMetricsCollector(
                 performanceAnalyzerController,configOverridesWrapper));
+        scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new AdmissionControlMetricsCollector());
         try {
             Class.forName(ShardIndexingPressureMetricsCollector.SHARD_INDEXING_PRESSURE_CLASS_NAME);
             scheduledMetricCollectorsExecutor.addScheduledMetricCollector(new ShardIndexingPressureMetricsCollector(

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/AdmissionControlMetricsCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/AdmissionControlMetricsCollector.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.
@@ -25,7 +25,6 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.met
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.elasticsearch.cluster.service.MasterService;
 
 import java.lang.reflect.Method;
 import java.util.Objects;

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/AdmissionControlMetricsCollector.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/AdmissionControlMetricsCollector.java
@@ -1,0 +1,166 @@
+/*
+ * Copyright 2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsProcessor;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.ExceptionsAndErrors;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
+
+import java.lang.reflect.Method;
+import java.util.Objects;
+
+/**
+ * AdmissionControlMetricsCollector collects `UsedQuota`, `TotalQuota`, RejectionCount
+ */
+public class AdmissionControlMetricsCollector extends PerformanceAnalyzerMetricsCollector implements MetricsProcessor {
+
+    private static final Logger LOG = LogManager.getLogger(AdmissionControlMetricsCollector.class);
+    private static final int sTimeInterval = MetricsConfiguration.SAMPLING_INTERVAL;
+    private static final int KEYS_PATH_LENGTH = 0;
+    private StringBuilder value;
+
+    // Global JVM Memory Pressure Controller
+    private final static String GLOBAL_JVMMP = "Global_JVMMP";
+
+    // Request Size Controller
+    private final static String REQUEST_SIZE = "Request_Size";
+
+    private final static String ADMISSION_CONTROLLER =
+            "com.sonian.elasticsearch.http.jetty.throttling.AdmissionController";
+
+    private final static String ADMISSION_CONTROL_SERVICE =
+            "com.sonian.elasticsearch.http.jetty.throttling.JettyAdmissionControlService";
+
+    public AdmissionControlMetricsCollector() {
+        super(sTimeInterval, "AdmissionControlMetricsCollector");
+        this.value = new StringBuilder();
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public void collectMetrics(long startTime) {
+        long startTimeMillis = System.currentTimeMillis();
+        try {
+            Class admissionController = Class.forName(ADMISSION_CONTROLLER);
+            Class jettyAdmissionControlService = Class.forName(ADMISSION_CONTROL_SERVICE);
+
+            Method getAdmissionController = jettyAdmissionControlService.getDeclaredMethod(
+                    "getAdmissionController",
+                    String.class);
+
+            Object globalJVMMP = getAdmissionController.invoke(null, GLOBAL_JVMMP);
+            Object requestSize = getAdmissionController.invoke(null, REQUEST_SIZE);
+
+            if(Objects.isNull(globalJVMMP) && Objects.isNull(requestSize)) {
+                return;
+            }
+
+            value.setLength(0);
+
+            Method getUsedQuota = admissionController.getDeclaredMethod("getUsedQuota");
+            Method getTotalQuota = admissionController.getDeclaredMethod("getTotalQuota");
+            Method getRejectionCount = admissionController.getDeclaredMethod("getRejectionCount");
+
+            if(!Objects.isNull(globalJVMMP)) {
+                value.append(PerformanceAnalyzerMetrics.getJsonCurrentMilliSeconds())
+                        .append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor)
+                        .append(new AdmissionControlMetrics(
+                                GLOBAL_JVMMP,
+                                (long)getUsedQuota.invoke(globalJVMMP),
+                                (long)getTotalQuota.invoke(globalJVMMP),
+                                (long)getRejectionCount.invoke(globalJVMMP)
+                        ).serialize());
+            }
+
+            if(!Objects.isNull(requestSize)) {
+                value.append(PerformanceAnalyzerMetrics.getJsonCurrentMilliSeconds())
+                        .append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor)
+                        .append(new AdmissionControlMetrics(
+                                REQUEST_SIZE,
+                                (long)getUsedQuota.invoke(requestSize),
+                                (long)getTotalQuota.invoke(requestSize),
+                                (long)getRejectionCount.invoke(requestSize)
+                        ).serialize());
+            }
+
+            saveMetricValues(value.toString(), startTime);
+        } catch (ClassNotFoundException e) {
+            LOG.debug("AdmissionControl not detected. Skipping AdmissionControlMetricsCollector");
+        } catch(Exception ex) {
+            PerformanceAnalyzerApp.ERRORS_AND_EXCEPTIONS_AGGREGATOR.updateStat(
+                    ExceptionsAndErrors.ADMISSION_CONTROL_COLLECTOR_ERROR, getCollectorName(),
+                    System.currentTimeMillis() - startTimeMillis);
+            LOG.debug("Exception in collecting AdmissionControl Metrics: {} for startTime {}",
+                    ex::toString, () -> startTime);
+        }
+    }
+
+    @Override
+    public String getMetricsPath(long startTime, String... keysPath) {
+        if (keysPath.length != KEYS_PATH_LENGTH) {
+            throw new RuntimeException("keys length should be " + KEYS_PATH_LENGTH);
+        }
+        return PerformanceAnalyzerMetrics.generatePath(startTime,
+                PerformanceAnalyzerMetrics.sAdmissionControlMetricsPath);
+    }
+
+    static class AdmissionControlMetrics extends MetricStatus {
+
+        private String controllerName;
+        private long current;
+        private long threshold;
+        private long rejectionCount;
+
+        public AdmissionControlMetrics() {
+            super();
+        }
+
+        public AdmissionControlMetrics(String controllerName, long current, long threshold, long rejectionCount) {
+            super();
+            this.controllerName = controllerName;
+            this.current = current;
+            this.threshold = threshold;
+            this.rejectionCount = rejectionCount;
+        }
+
+        @JsonProperty(AllMetrics.AdmissionControlDimension.Constants.CONTROLLER_NAME)
+        public String getControllerName() {
+            return controllerName;
+        }
+
+        @JsonProperty(AllMetrics.AdmissionControlValue.Constants.CURRENT_VALUE)
+        public long getCurrent() {
+            return current;
+        }
+
+        @JsonProperty(AllMetrics.AdmissionControlValue.Constants.THRESHOLD_VALUE)
+        public long getThreshold() {
+            return threshold;
+        }
+
+        @JsonProperty(AllMetrics.AdmissionControlValue.Constants.REJECTION_COUNT)
+        public long getRejectionCount() {
+            return rejectionCount;
+        }
+    }
+
+}

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/util/Utils.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/util/Utils.java
@@ -16,6 +16,7 @@
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.util;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.ESResources;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.AdmissionControlMetricsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.CacheConfigMetricsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.FaultDetectionMetricsCollector;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors.ShardIndexingPressureMetricsCollector;
@@ -47,6 +48,7 @@ public class Utils {
 
     public static void configureMetrics() {
         MetricsConfiguration.MetricConfig cdefault = MetricsConfiguration.cdefault ;
+        MetricsConfiguration.CONFIG_MAP.put(AdmissionControlMetricsCollector.class, cdefault);
         MetricsConfiguration.CONFIG_MAP.put(CacheConfigMetricsCollector.class, cdefault);
         MetricsConfiguration.CONFIG_MAP.put(CircuitBreakerCollector.class, cdefault);
         MetricsConfiguration.CONFIG_MAP.put(ThreadPoolMetricsCollector.class, cdefault);

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/AdmissionControlMetricsCollectorTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/AdmissionControlMetricsCollectorTests.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * Copyright 2021 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License").
  * You may not use this file except in compliance with the License.

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/AdmissionControlMetricsCollectorTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/AdmissionControlMetricsCollectorTests.java
@@ -1,0 +1,44 @@
+/*
+ * Copyright 2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+package com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors;
+
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.CustomMetricsLocationTestBase;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.Event;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class AdmissionControlMetricsCollectorTests extends CustomMetricsLocationTestBase {
+
+    @Test
+    public void admissionControlMetricsCollector() {
+        MetricsConfiguration.CONFIG_MAP.put(AdmissionControlMetricsCollector.class, MetricsConfiguration.cdefault);
+        AdmissionControlMetricsCollector admissionControlMetricsCollector = new AdmissionControlMetricsCollector();
+
+        long startTimeInMills = System.currentTimeMillis();
+        admissionControlMetricsCollector.saveMetricValues("testMetric", startTimeInMills);
+
+        List<Event> metrics =  new ArrayList<>();
+        PerformanceAnalyzerMetrics.metricQueue.drainTo(metrics);
+        assertEquals(1, metrics.size());
+        assertEquals("testMetric", metrics.get(0).value);
+    }
+}


### PR DESCRIPTION
*Issue #, if available:* 
https://github.com/opendistro-for-elasticsearch/performance-analyzer-rca/issues/570

*Description of changes:*
Publish AdmissionControl framework (external) metrics. These metrics are generated at node level.
- rejectionCount - Keeps track of the rejection count.
- currentValue - Keeps track of the controller's resource (Global JVM Memory Pressure / Request Size) current value.
- thresholdValue - Keeps track of the controller's resource (Global JVM Memory Pressure / Request Size) threshold value. 

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
