### PR TITLE
change default clone branch to "main"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ buildscript {
 
     ext {
         es_version = System.getProperty("es.version", "7.10.2")
+        gitDefaultBranch = 'main'
     }
     // This isn't applying from repositories.gradle so repeating it here
     repositories {
@@ -300,6 +301,7 @@ task cloneGitRepo(type: GitClone) {
     rcaDir = Paths.get(getProject().getBuildDir().toString(), "performance-analyzer-rca").toString()
     def destination = file(rcaDir)
     uri = "https://github.com/opendistro-for-elasticsearch/performance-analyzer-rca.git"
+    branch = gitDefaultBranch
     destinationPath = destination
     bare = false
     enabled = !destination.exists() // to clone only once


### PR DESCRIPTION
There is an error when building PA plugin by running ./gradlew build, and an empty PA-RCA folder will be created under the build folder. The reason behind this error is that the cloneGitRepo task in the gradle build script will clone the "Master" branch of PA-RCA, however, the default branch in PA-RCA has already been changed to "main".

This PR modified the build.gradle file to change the git default branch to "main". After this changed, the PA plugin can be built.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.