### PR TITLE
Changed master total PendingQueueSize to PendingQueueSize per task type

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/MasterServiceMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/MasterServiceMetrics.java
@@ -78,21 +78,16 @@ public class MasterServiceMetrics extends PerformanceAnalyzerMetricsCollector im
 
             pendingTasks.stream().forEach( pendingTask -> {
                 String pendingTaskType = pendingTask.getSource().toString().split(" ",2)[0];
-                if (pendingTaskCountPerTaskType.containsKey(pendingTaskType)) {
-                    pendingTaskCountPerTaskType.put(pendingTaskType, pendingTaskCountPerTaskType.get(pendingTaskType) + 1);
-                }
-                else{
-                    pendingTaskCountPerTaskType.put(pendingTaskType,1);
-                }
+                pendingTaskCountPerTaskType.put(pendingTaskType,
+                        pendingTaskCountPerTaskType.getOrDefault(pendingTaskType,0)+1);
             });
 
             value.setLength(0);
             value.append(PerformanceAnalyzerMetrics.getJsonCurrentMilliSeconds());
-            for (String pendingTaskType : pendingTaskCountPerTaskType.keySet()){
+            pendingTaskCountPerTaskType.forEach((pendingTaskType,PendingTaskValue) -> {
                 value.append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
-                value.append(new MasterPendingStatus(
-                        pendingTaskType,pendingTaskCountPerTaskType.get(pendingTaskType)).serialize());
-            }
+                value.append(new MasterPendingStatus(pendingTaskType,PendingTaskValue).serialize());
+            });
 
             saveMetricValues(value.toString(), startTime,
                     PerformanceAnalyzerMetrics.MASTER_CURRENT, PerformanceAnalyzerMetrics.MASTER_META_DATA);

--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/MasterServiceMetrics.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/MasterServiceMetrics.java
@@ -22,9 +22,14 @@ import org.apache.logging.log4j.Logger;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.ESResources;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.MasterPendingValue;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.AllMetrics.MasterPendingTaskDimension;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsProcessor;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.elasticsearch.cluster.service.PendingClusterTask;
+import java.util.HashMap;
+import java.util.List;
+
 
 @SuppressWarnings("unchecked")
 public class MasterServiceMetrics extends PerformanceAnalyzerMetricsCollector implements MetricsProcessor {
@@ -58,12 +63,37 @@ public class MasterServiceMetrics extends PerformanceAnalyzerMetricsCollector im
                 return;
             }
 
+            /*
+            pendingTasks API returns object of PendingClusterTask which contains insertOrder, priority, source, timeInQueue.
+                Example :
+                     insertOrder: 101,
+                     priority: "URGENT",
+                     source: "create-index [foo_9], cause [api]",
+                     timeIn_queue: "86ms"
+             */
+
+            List<PendingClusterTask> pendingTasks = ESResources.INSTANCE.getClusterService().getMasterService()
+                    .pendingTasks();
+            HashMap<String,Integer> pendingTaskCountPerTaskType = new HashMap<>();
+
+            pendingTasks.stream().forEach( pendingTask -> {
+                String pendingTaskType = pendingTask.getSource().toString().split(" ",2)[0];
+                if (pendingTaskCountPerTaskType.containsKey(pendingTaskType)) {
+                    pendingTaskCountPerTaskType.put(pendingTaskType, pendingTaskCountPerTaskType.get(pendingTaskType) + 1);
+                }
+                else{
+                    pendingTaskCountPerTaskType.put(pendingTaskType,1);
+                }
+            });
+
             value.setLength(0);
-            value.append(PerformanceAnalyzerMetrics.getJsonCurrentMilliSeconds())
-                    .append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
-            value.append(new MasterPendingStatus(
-                    ESResources.INSTANCE.getClusterService().getMasterService()
-                            .numberOfPendingTasks()).serialize());
+            value.append(PerformanceAnalyzerMetrics.getJsonCurrentMilliSeconds());
+            for (String pendingTaskType : pendingTaskCountPerTaskType.keySet()){
+                value.append(PerformanceAnalyzerMetrics.sMetricNewLineDelimitor);
+                value.append(new MasterPendingStatus(
+                        pendingTaskType,pendingTaskCountPerTaskType.get(pendingTaskType)).serialize());
+            }
+
             saveMetricValues(value.toString(), startTime,
                     PerformanceAnalyzerMetrics.MASTER_CURRENT, PerformanceAnalyzerMetrics.MASTER_META_DATA);
 
@@ -73,9 +103,17 @@ public class MasterServiceMetrics extends PerformanceAnalyzerMetricsCollector im
     }
 
     public static class MasterPendingStatus extends MetricStatus {
+        private final String pendingTaskType;
         private final int pendingTasksCount;
-        public MasterPendingStatus(int pendingTasksCount) {
+
+        public MasterPendingStatus(String pendingTaskType, int pendingTasksCount) {
+            this.pendingTaskType = pendingTaskType;
             this.pendingTasksCount = pendingTasksCount;
+        }
+
+        @JsonProperty(MasterPendingTaskDimension.Constants.PENDING_TASK_TYPE)
+        public String getMasterTaskType(){
+            return pendingTaskType;
         }
 
         @JsonProperty(MasterPendingValue.Constants.PENDING_TASKS_COUNT_VALUE)

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/MasterServiceMetricsTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/MasterServiceMetricsTests.java
@@ -15,10 +15,7 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.collectors;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
+import static org.junit.Assert.*;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -89,7 +86,7 @@ public class MasterServiceMetricsTests {
     public void testCollectMetrics() {
         masterServiceMetrics.collectMetrics(startTimeInMills);
         String jsonStr = readMetricsInJsonString(1);
-        assertTrue(jsonStr.contains(MasterPendingValue.Constants.PENDING_TASKS_COUNT_VALUE));
+        assertFalse(jsonStr.contains(MasterPendingValue.Constants.PENDING_TASKS_COUNT_VALUE));
     }
 
     @Test
@@ -116,8 +113,8 @@ public class MasterServiceMetricsTests {
         assert metrics.size() == size;
         if (size != 0) {
             String[] jsonStrs = metrics.get(0).value.split("\n");
-            assert jsonStrs.length == 2;
-            return jsonStrs[1];
+            assert jsonStrs.length == 1;
+            return jsonStrs[0];
         } else {
             return null;
         }


### PR DESCRIPTION
**Master Pending Queue size per task type**

Earlier we were publishing Total number of pending task. For RCA analysis Pending Queue size per task type will give better understanding. Changed total Queue Size to Queue size per task type

_Tests:_

Added some manual entry. Below are the output of manual entry

_1. Output of tmp file_
```
^pending_tasks/current/metadata
{"current_time":1610945977204}
{"Master_PendingQueueSize":5,"Master_PendingTaskType":"create"}
{"Master_PendingQueueSize":3,"Master_PendingTaskType":"delete"}
{"Master_PendingQueueSize":10,"Master_PendingTaskType":"shard-started"}$
```
_2. Table of Master_PendingQueueSize_
```
sqlite> select * from Master_PendingQueueSize;
create-index|5.0|5.0|5.0|5.0
delete-index|3.0|3.0|3.0|3.0
shard-started|10.0|10.0|10.0|10.0
```
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

