### PR TITLE
AdmissionControl: Clear metricQueue before running test

### DIFF
--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/AdmissionControlMetricsCollectorTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/collectors/AdmissionControlMetricsCollectorTests.java
@@ -19,16 +19,23 @@ import static org.junit.Assert.assertEquals;
 
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.CustomMetricsLocationTestBase;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.Event;
-import java.util.ArrayList;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.util.TestUtil;
 import java.util.List;
-import org.junit.Ignore;
+import org.junit.Before;
 import org.junit.Test;
 
 public class AdmissionControlMetricsCollectorTests extends CustomMetricsLocationTestBase {
 
-    @Ignore
+    @Override
+    @Before
+    public void setUp() throws Exception {
+        super.setUp();
+        // clean metricQueue before running every test
+        TestUtil.readEvents();
+        System.setProperty("performanceanalyzer.metrics.log.enabled", "False");
+    }
+
     @Test
     public void admissionControlMetricsCollector() {
         MetricsConfiguration.CONFIG_MAP.put(
@@ -39,8 +46,7 @@ public class AdmissionControlMetricsCollectorTests extends CustomMetricsLocation
         long startTimeInMills = System.currentTimeMillis();
         admissionControlMetricsCollector.saveMetricValues("testMetric", startTimeInMills);
 
-        List<Event> metrics = new ArrayList<>();
-        PerformanceAnalyzerMetrics.metricQueue.drainTo(metrics);
+        List<Event> metrics = TestUtil.readEvents();
         assertEquals(1, metrics.size());
         assertEquals("testMetric", metrics.get(0).value);
     }


### PR DESCRIPTION
*Issue #, if available:* https://github.com/opendistro-for-elasticsearch/performance-analyzer/issues/299

*Description of changes:*
AdmissionControl: Clear metricQueue before running test

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
