### PR TITLE
Export JAVA_HOME in performance-analyzer-agent script

### DIFF
--- a/pa_bin/performance-analyzer-agent
+++ b/pa_bin/performance-analyzer-agent
@@ -20,7 +20,7 @@ if [ -z "$2" ]; then
     exit 1
   fi
 else
-  JAVA_HOME=$2
+  export JAVA_HOME=$2
 fi
 
 # Instead of the supervisor executing peformance-analyzer-agent from the plugin location,


### PR DESCRIPTION
*Issue #:* #302

*Description of changes:*
Exporting `JAVA_HOME` variable in` performance-analyzer-agent` which can be passed as second argument. This way, the path is accessible for the process started by `exec` and the agent can be started using elasticsearch embedded JDK, with no system JDK.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
