### PR TITLE
Create writer file if metrics are available

### DIFF
--- a/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/writer/EventLogQueueProcessor.java
+++ b/src/main/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/writer/EventLogQueueProcessor.java
@@ -15,8 +15,15 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.writer;
 
+
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.PerformanceAnalyzerApp;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PerformanceAnalyzerController;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.http_action.config.PerformanceAnalyzerConfigAction;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.rca.framework.metrics.WriterMetrics;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.Event;
+import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.EventLogFileHandler;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CancellationException;
@@ -28,29 +35,21 @@ import java.util.concurrent.TimeUnit;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.config.PerformanceAnalyzerController;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.http_action.config.PerformanceAnalyzerConfigAction;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsConfiguration;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.Event;
-import com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared.EventLogFileHandler;
-
 public class EventLogQueueProcessor {
-    private static final Logger LOG = LogManager.getLogger(
-            EventLogQueueProcessor.class);
+    private static final Logger LOG = LogManager.getLogger(EventLogQueueProcessor.class);
 
-    private final ScheduledExecutorService writerExecutor =
-            Executors.newScheduledThreadPool(1);
+    private final ScheduledExecutorService writerExecutor = Executors.newScheduledThreadPool(1);
     private final EventLogFileHandler eventLogFileHandler;
     private final long initialDelayMillis;
     private final long purgePeriodicityMillis;
     private final PerformanceAnalyzerController controller;
     private long lastTimeBucket;
 
-    public EventLogQueueProcessor(EventLogFileHandler eventLogFileHandler,
-                                  long initialDelayMillis,
-                                  long purgePeriodicityMillis,
-                                  PerformanceAnalyzerController controller) {
+    public EventLogQueueProcessor(
+            EventLogFileHandler eventLogFileHandler,
+            long initialDelayMillis,
+            long purgePeriodicityMillis,
+            PerformanceAnalyzerController controller) {
         this.eventLogFileHandler = eventLogFileHandler;
         this.initialDelayMillis = initialDelayMillis;
         this.purgePeriodicityMillis = purgePeriodicityMillis;
@@ -60,26 +59,29 @@ public class EventLogQueueProcessor {
 
     public void scheduleExecutor() {
         ScheduledFuture<?> futureHandle =
-                writerExecutor.scheduleAtFixedRate(this::purgeQueueAndPersist,
+                writerExecutor.scheduleAtFixedRate(
+                        this::purgeQueueAndPersist,
                         // The initial delay is critical here. The collector threads
                         // start immediately with the Plugin. This thread purges the
                         // queue and writes data to file. So, it waits for one run of
                         // the collectors to complete before it starts, so that the
                         // queue has elements to drain.
                         initialDelayMillis,
-                        purgePeriodicityMillis, TimeUnit.MILLISECONDS);
-        new Thread(() -> {
-            try {
-                futureHandle.get();
-            } catch (InterruptedException e) {
-                LOG.error("Scheduled execution was interrupted", e);
-            } catch (CancellationException e) {
-                LOG.warn("Watcher thread has been cancelled", e);
-            } catch (ExecutionException e) {
-                LOG.error("QueuePurger interrupted. Caused by ",
-                        e.getCause());
-            }
-        }).start();
+                        purgePeriodicityMillis,
+                        TimeUnit.MILLISECONDS);
+        new Thread(
+                        () -> {
+                            try {
+                                futureHandle.get();
+                            } catch (InterruptedException e) {
+                                LOG.error("Scheduled execution was interrupted", e);
+                            } catch (CancellationException e) {
+                                LOG.warn("Watcher thread has been cancelled", e);
+                            } catch (ExecutionException e) {
+                                LOG.error("QueuePurger interrupted. Caused by ", e.getCause());
+                            }
+                        })
+                .start();
     }
 
     // This executes every purgePeriodicityMillis interval.
@@ -95,8 +97,9 @@ public class EventLogQueueProcessor {
             if (PerformanceAnalyzerMetrics.metricQueue.size() > 0) {
                 List<Event> metrics = new ArrayList<>();
                 PerformanceAnalyzerMetrics.metricQueue.drainTo(metrics);
-                LOG.info("Performance Analyzer no longer enabled. Drained the" +
-                        "queue to remove stale data.");
+                LOG.info(
+                        "Performance Analyzer no longer enabled. Drained the"
+                                + "queue to remove stale data.");
             }
             return;
         }
@@ -111,9 +114,10 @@ public class EventLogQueueProcessor {
         // Calculate the timestamp on the file. For example, lets say the
         // purging started at time 12.5 then all the events between 5-10
         // are written to a file with name 5.
-        long timeBucket = PerformanceAnalyzerMetrics.getTimeInterval(
-                currentTimeMillis, MetricsConfiguration.SAMPLING_INTERVAL) -
-                MetricsConfiguration.SAMPLING_INTERVAL;
+        long timeBucket =
+                PerformanceAnalyzerMetrics.getTimeInterval(
+                                currentTimeMillis, MetricsConfiguration.SAMPLING_INTERVAL)
+                        - MetricsConfiguration.SAMPLING_INTERVAL;
 
         // When we are trying to collect the metrics for the 5th-10th second,
         // but doing that in the 12.5th second, there is a chance that a
@@ -131,9 +135,10 @@ public class EventLogQueueProcessor {
             } else if (entry.epoch == nextTimeBucket) {
                 nextMetrics.add(entry);
             } else {
-                //increment stale_metrics count when metrics to be collected is falling behind the current bucket
+                // increment stale_metrics count when metrics to be collected is falling behind the
+                // current bucket
                 PerformanceAnalyzerApp.WRITER_METRICS_AGGREGATOR.updateStat(
-                    WriterMetrics.STALE_METRICS, "", 1);
+                        WriterMetrics.STALE_METRICS, "", 1);
             }
         }
 
@@ -148,17 +153,19 @@ public class EventLogQueueProcessor {
         LOG.debug("Writing to disk complete.");
     }
 
-    private void writeAndRotate(final List<Event> currMetrics,
-                                long currTimeBucket,
-                                long currentTime) {
+    private void writeAndRotate(
+            final List<Event> currMetrics, long currTimeBucket, long currentTime) {
         // Going by the continuing example, we will rotate the 5.tmp file to
         // 5, which contains the metrics with epoch 5-10, whenever the purger
         // runs after the 15th second.
         if (lastTimeBucket != 0 && lastTimeBucket != currTimeBucket) {
             eventLogFileHandler.renameFromTmp(lastTimeBucket);
         }
-        // This appends the data to a file named <currTimeBucket>.tmp
-        eventLogFileHandler.writeTmpFile(currMetrics, currTimeBucket);
+        // Append to the tmp file only if we have metrics to publish.
+        if (!currMetrics.isEmpty()) {
+            // This appends the data to a file named <currTimeBucket>.tmp
+            eventLogFileHandler.writeTmpFile(currMetrics, currTimeBucket);
+        }
         lastTimeBucket = currTimeBucket;
     }
 }

--- a/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader_writer_shared/EventLogFileHandlerTests.java
+++ b/src/test/java/com/amazon/opendistro/elasticsearch/performanceanalyzer/reader_writer_shared/EventLogFileHandlerTests.java
@@ -15,6 +15,8 @@
 
 package com.amazon.opendistro.elasticsearch.performanceanalyzer.reader_writer_shared;
 
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -25,6 +27,12 @@ import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.MetricsCo
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.metrics.PerformanceAnalyzerMetrics;
 import com.amazon.opendistro.elasticsearch.performanceanalyzer.writer.EventLogQueueProcessor;
 import java.io.File;
+import java.io.FileNotFoundException;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Scanner;
+import org.junit.After;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
@@ -33,17 +41,93 @@ public class EventLogFileHandlerTests {
     @Mock private PerformanceAnalyzerController mockController;
     @Mock private PerformanceAnalyzerConfigAction configAction;
 
-    String pathToTestMetricsDir;
+    private final String pathToTestMetricsDir = "/tmp/testMetrics/";
+    private final EventLog eventLog = new EventLog();
+    private final EventLogFileHandler eventLogFileHandler =
+            new EventLogFileHandler(eventLog, pathToTestMetricsDir);
+    private EventLogQueueProcessor queuePurgerAndPersistor;
 
     @Before
     public void init() {
         initMocks(this);
-        pathToTestMetricsDir = "/tmp/testMetrics/";
         deleteDirectory(new File(pathToTestMetricsDir));
         boolean newDir = new File(pathToTestMetricsDir).mkdir();
         when(mockController.isPerformanceAnalyzerEnabled()).thenReturn(true);
         PerformanceAnalyzerConfigAction.setInstance(configAction);
+
+        queuePurgerAndPersistor =
+                new EventLogQueueProcessor(
+                        eventLogFileHandler,
+                        MetricsConfiguration.SAMPLING_INTERVAL,
+                        MetricsConfiguration.SAMPLING_INTERVAL,
+                        mockController);
+        System.setProperty("performanceanalyzer.metrics.log.enabled", "False");
     }
+
+    @After
+    public void cleanup() {
+        deleteDirectory(new File(pathToTestMetricsDir));
+    }
+
+    @Test
+    public void testFileWithMetrics() throws InterruptedException {
+        generateWriterFile(5);
+        queuePurgerAndPersistor.purgeQueueAndPersist();
+        String bucketTime1 = String.valueOf(getTimeBucket());
+        assertTrue(
+                "Tmp file should be present if metrics are available",
+                isFilePresent(getTmpFileName(bucketTime1)));
+        Assert.assertEquals(5, checkFileForMetrics(getTmpFileName(bucketTime1)));
+
+        // Generate the next writer file tmp file
+        Thread.sleep(5_000);
+        generateWriterFile(4);
+        queuePurgerAndPersistor.purgeQueueAndPersist();
+        String bucketTime2 = String.valueOf(getTimeBucket());
+        assertTrue(
+                "Tmp file should be present if metrics are available",
+                isFilePresent(getTmpFileName(bucketTime2)));
+        Assert.assertEquals(4, checkFileForMetrics(getTmpFileName(bucketTime2)));
+
+        // Waiting and calling purgeQueueAndPersist method
+        // for tmp file to be renamed to timestamp file
+        Thread.sleep(5_000);
+        queuePurgerAndPersistor.purgeQueueAndPersist();
+        assertTrue(
+                "Timestamp file should be present if tmp file is present",
+                isFilePresent(bucketTime1));
+        Assert.assertEquals(5, checkFileForMetrics(bucketTime1));
+
+        // Waiting and calling purgeQueueAndPersist method
+        // for tmp file to be renamed to timestamp file
+        Thread.sleep(5_000);
+        queuePurgerAndPersistor.purgeQueueAndPersist();
+        assertTrue(
+                "Timestamp file should be present if tmp file is present",
+                isFilePresent(bucketTime1));
+        Assert.assertEquals(4, checkFileForMetrics(bucketTime2));
+    }
+
+    @Test
+    public void testNoFileWithNoMetrics() throws InterruptedException {
+        queuePurgerAndPersistor.purgeQueueAndPersist();
+        String bucketTime1 = String.valueOf(getTimeBucket());
+        assertFalse(
+                "Tmp file should not be present if metrics are not available",
+                isFilePresent(getTmpFileName(bucketTime1)));
+
+        // Waiting and calling purgeQueueAndPersist method
+        // for tmp file to be renamed to timestamp file
+        Thread.sleep(5_000);
+        queuePurgerAndPersistor.purgeQueueAndPersist();
+        Thread.sleep(5_000);
+        queuePurgerAndPersistor.purgeQueueAndPersist();
+        assertFalse(
+                "Timestamp file should not be present if tmp file is not present",
+                isFilePresent(bucketTime1));
+    }
+
+    // TODO: Write a test for case when one single Event is larger than BUFFER_SIZE
 
     private boolean deleteDirectory(File directoryToBeDeleted) {
         File[] allContents = directoryToBeDeleted.listFiles();
@@ -55,11 +139,6 @@ public class EventLogFileHandlerTests {
         return directoryToBeDeleted.delete();
     }
 
-    // @After
-    public void cleanup() {
-        deleteDirectory(new File(pathToTestMetricsDir));
-    }
-
     private long generateWriterFile(int count) {
         long currTime = System.currentTimeMillis();
         HeapMetricsCollector heapMetricsCollector = new HeapMetricsCollector();
@@ -67,39 +146,40 @@ public class EventLogFileHandlerTests {
         for (int i = 0; i < count; i++) {
             heapMetricsCollector.collectMetrics(currTime);
         }
-
-        EventLog eventLog = new EventLog();
-        EventLogFileHandler eventLogFileHandler = new EventLogFileHandler(eventLog, pathToTestMetricsDir);
-        EventLogQueueProcessor queuePurgerAndPersistor = new EventLogQueueProcessor(eventLogFileHandler,
-                MetricsConfiguration.SAMPLING_INTERVAL, MetricsConfiguration.SAMPLING_INTERVAL, mockController);
-        queuePurgerAndPersistor.purgeQueueAndPersist();
-        return PerformanceAnalyzerMetrics.getTimeInterval(currTime);
+        return currTime;
     }
 
-    @Test
-    public void write() {
-        System.setProperty("performanceanalyzer.metrics.log.enabled", "False");
-        generateWriterFile(4);
+    private long getTimeBucket() {
+        return PerformanceAnalyzerMetrics.getTimeInterval(
+                System.currentTimeMillis(), MetricsConfiguration.SAMPLING_INTERVAL);
     }
 
-    @Test
-    public void readSmallFile() {
-        System.setProperty("performanceanalyzer.metrics.log.enabled", "False");
-        // String filename = String.valueOf(generateWriterFile(4));
-        EventLog eventLog = new EventLog();
-        EventLogFileHandler eventLogFileHandler = new EventLogFileHandler(eventLog, "test_files/new_format");
-        // Assert.assertEquals(4, eventLogFileHandler.read("1566152850000").size());
+    private String getTmpFileName(String filename) {
+        return filename + ".tmp";
     }
 
-    @Test
-    public void readLargeFile() {
-        System.setProperty("performanceanalyzer.metrics.log.enabled", "False");
-        String filename = String.valueOf(generateWriterFile(7));
-        EventLog eventLog = new EventLog();
-        EventLogFileHandler eventLogFileHandler = new EventLogFileHandler(eventLog, pathToTestMetricsDir);
-        // eventLogFileHandler.read(filename);
+    private boolean isFilePresent(String filename) {
+        Path pathToFile = Paths.get(pathToTestMetricsDir, filename);
+        File tempFile = new File(pathToFile.toString());
+        return tempFile.exists();
     }
 
-
-    // TODO: Write a test for case when one single Event is larger than BUFFER_SIZE
+    private long checkFileForMetrics(String filename) {
+        Path pathToFile = Paths.get(pathToTestMetricsDir, filename);
+        File tempFile = new File(pathToFile.toString());
+        long metrics_count = 0;
+        try {
+            Scanner reader = new Scanner(tempFile);
+            while (reader.hasNextLine()) {
+                String line = reader.nextLine();
+                if (line.contains("current_time")) {
+                    metrics_count += 1;
+                }
+            }
+            reader.close();
+        } catch (FileNotFoundException e) {
+            Assert.fail("File not found filename:" + filename);
+        }
+        return metrics_count;
+    }
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/opendistro-for-elasticsearch/performance-analyzer/issues/313

*Description of changes:*
We write to tmp files first before renaming to actual epoch file.
Append/ Create to the tmp file only if we have metrics to publish.

Developer's Certificate of Origin 1.1

By making a contribution to this project, I certify that:

(a) The contribution was created in whole or in part by me and I
    have the right to submit it under the open source license
    indicated in the file; or

(b) The contribution is based upon previous work that, to the best
    of my knowledge, is covered under an appropriate open source
    license and I have the right under that license to submit that
    work with modifications, whether created in whole or in part
    by me, under the same open source license (unless I am
    permitted to submit under a different license), as indicated
    in the file; or

(c) The contribution was provided directly to me by some other
    person who certified (a), (b) or (c) and I have not modified
    it.

(d) I understand and agree that this project and the contribution
    are public and that a record of the contribution (including all
    personal information I submit with it, including my sign-off) is
    maintained indefinitely and may be redistributed consistent with
    this project or the open source license(s) involved.
